### PR TITLE
[FEAT] heroArea에 날짜타입픽커 & 인원픽커

### DIFF
--- a/pick-habju/src/components/DatePicker/DatePicker.tsx
+++ b/pick-habju/src/components/DatePicker/DatePicker.tsx
@@ -17,22 +17,26 @@ import DatePickerBody from './Body/DatePickerBody';
  */
 
 const DatePicker = ({ onChange, onConfirm, onCancel }: DatePickerProps) => {
-  const [selected, setSelected] = useState<Date[]>([]);
+  const today = new Date();
+  const todayAtMidnight = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+
+  // 항상 기본 선택은 '당일'
+  const [selected, setSelected] = useState<Date[]>([todayAtMidnight]);
   const [activeStartDate, setActiveStartDate] = useState<Date>(() => {
-    const today = new Date();
-    return new Date(today.getFullYear(), today.getMonth(), 1);
+    return new Date(todayAtMidnight.getFullYear(), todayAtMidnight.getMonth(), 1);
   });
 
   // 외부에서 props로 selectedDates를 전달했을 때, 업데이트 하기 위한 로직입니다.
   // selectedDates를 삭제 처리하였습니다. (부모에서 전달할 수 없습니다.)
 
+  const isSameDay = (a: Date, b: Date) =>
+    a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
+
   const toggleDate = (date: Date) => {
     const exists = selected.some((d) => d.getTime() === date.getTime());
 
-    // 중복 선택 방지 로직:
-    // 클릭된 날짜가 이미 선택된 날짜이면 선택 해제 (빈 배열)
-    // 클릭된 날짜가 선택되지 않았으면 해당 날짜 하나만 선택 (해당 날짜를 가진 배열)
-    const updated = exists ? [] : [date];
+    // 단일 선택만 허용, 그리고 항상 최소 1개(기본: 당일) 유지
+    const updated = exists ? [todayAtMidnight] : [date];
 
     setSelected(updated);
     onChange?.(updated);
@@ -62,6 +66,15 @@ const DatePicker = ({ onChange, onConfirm, onCancel }: DatePickerProps) => {
         onChange={toggleDate}
         onActiveStartDateChange={({ activeStartDate }) => activeStartDate && setActiveStartDate(activeStartDate)}
       />
+      {selected.length > 0 && isSameDay(selected[0], todayAtMidnight) && (
+        <div className="flex w-full px-3 py-2.5 items-center justify-start">
+          <p className="font-modal-calcdetail text-gray-300 text-left">
+            당일 예약은 취소 시 전액 위약금이 발생합니다.
+            <br />
+            신중히 선택해주세요!
+          </p>
+        </div>
+      )}
       <PickerFooter onConfirm={handleConfirm} onCancel={handleCancel} />
     </div>
   );

--- a/pick-habju/src/components/DatePicker/DatePicker.tsx
+++ b/pick-habju/src/components/DatePicker/DatePicker.tsx
@@ -16,12 +16,14 @@ import DatePickerBody from './Body/DatePickerBody';
  * 선택된 날짜는 외부에서 관리할 수 있으며, 확인/취소 버튼을 통해 선택을 완료하거나 취소할 수 있습니다.
  */
 
-const DatePicker = ({ onChange, onConfirm, onCancel }: DatePickerProps) => {
+const DatePicker = ({ onChange, onConfirm, onCancel, initialSelectedDate }: DatePickerProps) => {
   const today = new Date();
   const todayAtMidnight = new Date(today.getFullYear(), today.getMonth(), today.getDate());
 
-  // 항상 기본 선택은 '당일'
-  const [selected, setSelected] = useState<Date[]>([todayAtMidnight]);
+  // 항상 기본 선택은 '당일' (초기값 전달 시 해당 날짜로 설정)
+  const [selected, setSelected] = useState<Date[]>([
+    initialSelectedDate ? new Date(initialSelectedDate.getFullYear(), initialSelectedDate.getMonth(), initialSelectedDate.getDate()) : todayAtMidnight,
+  ]);
   const [activeStartDate, setActiveStartDate] = useState<Date>(() => {
     return new Date(todayAtMidnight.getFullYear(), todayAtMidnight.getMonth(), 1);
   });

--- a/pick-habju/src/components/DatePicker/DatePicker.types.ts
+++ b/pick-habju/src/components/DatePicker/DatePicker.types.ts
@@ -1,6 +1,6 @@
 export interface DatePickerProps {
-  /* 초기 선택된 날짜들 */
-  selectedDates?: Date[];
+  /* 초기 선택된 날짜 (단일 선택) */
+  initialSelectedDate?: Date;
   /* 날짜 선택 시 호출되는 콜백 */
   onChange?: (dates: Date[]) => void;
   /* 확인 버튼 클릭 시 호출되는 콜백 */

--- a/pick-habju/src/components/GuestCounterModal/GuestCounter/GuestCounter.stories.tsx
+++ b/pick-habju/src/components/GuestCounterModal/GuestCounter/GuestCounter.stories.tsx
@@ -17,15 +17,15 @@ const ControlledTemplate = (initialProps: { value: number; min?: number; max?: n
 };
 
 export const Default: Story = {
-  render: () => <ControlledTemplate value={1} min={0} max={13} />,
+  render: () => <ControlledTemplate value={12} min={1} max={30} />,
 };
 
 export const AtMinValue: Story = {
-  render: () => <ControlledTemplate value={0} min={0} max={13} />,
+  render: () => <ControlledTemplate value={1} min={1} max={30} />,
 };
 
 export const AtMaxValue: Story = {
-  render: () => <ControlledTemplate value={13} min={0} max={13} />,
+  render: () => <ControlledTemplate value={30} min={1} max={30} />,
 };
 
 export const CustomRange: Story = {

--- a/pick-habju/src/components/GuestCounterModal/GuestCounter/GuestCounter.tsx
+++ b/pick-habju/src/components/GuestCounterModal/GuestCounter/GuestCounter.tsx
@@ -2,7 +2,7 @@ import { Minus, Plus } from 'lucide-react';
 import clsx from 'clsx';
 import type { GuestCounterProps } from './GuestCounter.types';
 
-const GuestCounter = ({ value, onChange, min = 0, max = 15 }: GuestCounterProps) => {
+const GuestCounter = ({ value, onChange, min = 1, max = 30 }: GuestCounterProps) => {
   const handleIncrement = () => {
     if (value < max) onChange(value + 1);
   };

--- a/pick-habju/src/components/GuestCounterModal/GuestCounterModal.stories.tsx
+++ b/pick-habju/src/components/GuestCounterModal/GuestCounterModal.stories.tsx
@@ -33,7 +33,7 @@ const AlwaysOpenTemplate = (args: { initialCount?: number }) => {
 };
 
 export const Defalut: Story = {
-  render: () => <AlwaysOpenTemplate initialCount={1} />,
+  render: () => <AlwaysOpenTemplate initialCount={12} />,
   parameters: {
     docs: {
       description: {
@@ -55,11 +55,11 @@ export const WithInitialCount5: Story = {
 };
 
 export const WithInitialCountMax: Story = {
-  render: () => <AlwaysOpenTemplate initialCount={15} />,
+  render: () => <AlwaysOpenTemplate initialCount={30} />,
   parameters: {
     docs: {
       description: {
-        story: '최대 인원(15명)으로 초기값이 설정된 모달입니다.',
+        story: '최대 인원(30명)으로 초기값이 설정된 모달입니다.',
       },
     },
   },

--- a/pick-habju/src/components/GuestCounterModal/GuestCounterModal.tsx
+++ b/pick-habju/src/components/GuestCounterModal/GuestCounterModal.tsx
@@ -4,7 +4,7 @@ import Button from '../Button/Button';
 import { BtnSizeVariant, ButtonVariant } from '../Button/ButtonEnums';
 import type { GuestCounterModalProps } from './GuestCounterModal.types';
 
-const GuestCounterModal = ({ open, onClose, onConfirm, initialCount = 1 }: GuestCounterModalProps) => {
+const GuestCounterModal = ({ open, onClose, onConfirm, initialCount = 12 }: GuestCounterModalProps) => {
   const [guestCount, setGuestCount] = useState(initialCount);
 
   useEffect(() => {
@@ -31,7 +31,7 @@ const GuestCounterModal = ({ open, onClose, onConfirm, initialCount = 1 }: Guest
       <div className="font-modal-default text-primary-black">합주실 이용 인원을 입력해주세요</div>
 
       {/* 인원 수 카운터 */}
-      <GuestCounter value={guestCount} onChange={setGuestCount} min={1} max={15} />
+      <GuestCounter value={guestCount} onChange={setGuestCount} min={1} max={30} />
 
       {/* 확인 버튼 */}
       <div>

--- a/pick-habju/src/components/HeroArea/HeroArea.tsx
+++ b/pick-habju/src/components/HeroArea/HeroArea.tsx
@@ -1,13 +1,118 @@
+import { useCallback, useState } from 'react';
 import Button from '../Button/Button';
 import { BtnSizeVariant, ButtonVariant } from '../Button/ButtonEnums';
-
 import PersonCountInput from './Input/Person/PersonCountInput';
 import DateTimeInput from './Input/\bDate/DateTimeInput';
-
 import BackGroundImage from '../../assets/images/background.jpg';
 import type { HeroAreaProps } from './HeroArea.types';
+import DatePicker from '../DatePicker/DatePicker';
+import TimePicker from '../TimePicker/TimePicker';
+import { TimePeriod } from '../TimePicker/TimePickerEnums';
+import ToastMessage from '../ToastMessage/ToastMessage';
+import { showToastByKey } from '../../utils/showToastByKey';
+import { ReservationToastKey } from '../ToastMessage/ToastMessageEnums';
+import { useReservationActions, useReservationState } from '../../hook/useReservationStore';
+import { convertTo24Hour } from '../../utils/formatDate';
+import { useToastStore } from '../../store/toast/toastStore';
 
 const HeroArea = ({ dateTime, peopleCount, onDateTimeChange, onPersonCountChange, onSearch }: HeroAreaProps) => {
+  const [isDatePickerOpen, setIsDatePickerOpen] = useState(false);
+  const [isTimePickerOpen, setIsTimePickerOpen] = useState(false);
+  const [dateTimeText, setDateTimeText] = useState<string>(dateTime);
+  const { selectedDate } = useReservationState();
+  const actions = useReservationActions();
+  const isToastVisible = useToastStore((s) => s.isVisible);
+
+  const openDatePicker = useCallback(() => {
+    setIsDatePickerOpen(true);
+    onDateTimeChange?.();
+  }, [onDateTimeChange]);
+
+  const handleDateConfirm = useCallback(
+    (dates: Date[]) => {
+      actions.setDate(dates);
+      setIsDatePickerOpen(false);
+      setIsTimePickerOpen(true);
+    },
+    [actions]
+  );
+
+  const handleDateCancel = useCallback(() => {
+    setIsDatePickerOpen(false);
+  }, []);
+
+  const validateTime = useCallback(
+    (
+      startHour: number,
+      startPeriod: TimePeriod,
+      endHour: number,
+      endPeriod: TimePeriod
+    ): ReservationToastKey | null => {
+      const start24 = convertTo24Hour(startHour, startPeriod);
+      const end24 = convertTo24Hour(endHour, endPeriod);
+
+      // 1) 형식 오류: 시작과 종료가 완전히 동일한 경우만
+      if (start24 === end24 && startPeriod === endPeriod) {
+        return ReservationToastKey.INVALID_TYPE;
+      }
+
+      // 자정(12AM)은 다음날 24시로 간주하여 교차 자정 구간 허용
+      const adjustedEnd = end24 <= start24 ? end24 + 24 : end24;
+      const duration = adjustedEnd - start24; // 시간 단위
+
+      // 2) 5시간 초과
+      if (duration > 5) return ReservationToastKey.TOO_LONG;
+
+      // 3) 1시간 선택
+      if (duration === 1) return ReservationToastKey.TOO_SHORT;
+
+      // 4) 과거 시간 선택: 당일이고 시작 시간이 현재 시각 이전이면
+      if (selectedDate) {
+        const now = new Date();
+        const isSameDay =
+          selectedDate.getFullYear() === now.getFullYear() &&
+          selectedDate.getMonth() === now.getMonth() &&
+          selectedDate.getDate() === now.getDate();
+        if (isSameDay) {
+          const currentHour24 = now.getHours();
+          if (start24 <= currentHour24) return ReservationToastKey.PAST_TIME;
+        }
+      }
+
+      return null;
+    },
+    [selectedDate]
+  );
+
+  const handleTimeConfirm = useCallback(
+    (sh: number, sp: TimePeriod, eh: number, ep: TimePeriod) => {
+      const errorKey = validateTime(sh, sp, eh, ep);
+      if (errorKey) {
+        showToastByKey(errorKey);
+        return;
+      }
+      actions.setHourSlots(sh, sp, eh, ep);
+      setIsTimePickerOpen(false);
+
+      // 라벨 업데이트: M월 DD일 (요일) HH~HH시
+      if (selectedDate) {
+        const month = selectedDate.getMonth() + 1; // 1~12
+        const day = String(selectedDate.getDate()).padStart(2, '0');
+        const weekdayKorean = ['일', '월', '화', '수', '목', '금', '토'][selectedDate.getDay()];
+        const start24 = convertTo24Hour(sh, sp);
+        const rawEnd24 = convertTo24Hour(eh, ep);
+        const displayEndHour = rawEnd24 === 0 ? 24 : rawEnd24 <= start24 ? rawEnd24 + 24 : rawEnd24;
+        setDateTimeText(`${month}월 ${day}일 (${weekdayKorean}) ${start24}~${displayEndHour}시`);
+      }
+    },
+    [actions, validateTime, selectedDate]
+  );
+
+  const handleTimeCancel = useCallback(() => {
+    // 뒤로가기: TimePicker를 닫고 DatePicker로 복귀, 기존 날짜 유지
+    setIsTimePickerOpen(false);
+    setIsDatePickerOpen(true);
+  }, []);
   return (
     <div
       className="relative w-full h-97.5 flex flex-col items-center"
@@ -27,7 +132,7 @@ const HeroArea = ({ dateTime, peopleCount, onDateTimeChange, onPersonCountChange
 
         <div className="flex flex-col items-center">
           <div className="flex flex-col gap-3 mb-8">
-            <DateTimeInput dateTime={dateTime} onChangeClick={onDateTimeChange} />
+            <DateTimeInput dateTime={dateTimeText} onChangeClick={openDatePicker} />
             <PersonCountInput count={peopleCount} onChangeClick={onPersonCountChange} />
           </div>
           <div>
@@ -35,6 +140,28 @@ const HeroArea = ({ dateTime, peopleCount, onDateTimeChange, onPersonCountChange
           </div>
         </div>
       </div>
+
+      {(isDatePickerOpen || isTimePickerOpen) && (
+        <div className="fixed inset-0 z-50 flex justify-center items-center bg-black/80">
+          {/* wrapper 기준 폭으로 중앙 정렬 */}
+          <div className="w-[25.125rem] flex flex-col items-center">
+            {isDatePickerOpen && (
+              <DatePicker
+                onConfirm={handleDateConfirm}
+                onCancel={handleDateCancel}
+                initialSelectedDate={selectedDate ?? undefined}
+              />
+            )}
+            {isTimePickerOpen && (
+              <TimePicker onConfirm={handleTimeConfirm} onCancel={handleTimeCancel} disabled={isToastVisible} />
+            )}
+            {/* 토스트는 모달 하단에 배치되도록 아래에 둔다 */}
+            <div className="mt-3">
+              <ToastMessage />
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/pick-habju/src/components/HeroArea/HeroArea.tsx
+++ b/pick-habju/src/components/HeroArea/HeroArea.tsx
@@ -7,6 +7,7 @@ import BackGroundImage from '../../assets/images/background.jpg';
 import type { HeroAreaProps } from './HeroArea.types';
 import DatePicker from '../DatePicker/DatePicker';
 import TimePicker from '../TimePicker/TimePicker';
+import GuestCounterModal from '../GuestCounterModal/GuestCounterModal';
 import { TimePeriod } from '../TimePicker/TimePickerEnums';
 import ToastMessage from '../ToastMessage/ToastMessage';
 import { showToastByKey } from '../../utils/showToastByKey';
@@ -18,7 +19,9 @@ import { useToastStore } from '../../store/toast/toastStore';
 const HeroArea = ({ dateTime, peopleCount, onDateTimeChange, onPersonCountChange, onSearch }: HeroAreaProps) => {
   const [isDatePickerOpen, setIsDatePickerOpen] = useState(false);
   const [isTimePickerOpen, setIsTimePickerOpen] = useState(false);
+  const [isGuestModalOpen, setIsGuestModalOpen] = useState(false);
   const [dateTimeText, setDateTimeText] = useState<string>(dateTime);
+  const [peopleCountText, setPeopleCountText] = useState<number>(peopleCount);
   const { selectedDate } = useReservationState();
   const actions = useReservationActions();
   const isToastVisible = useToastStore((s) => s.isVisible);
@@ -27,6 +30,11 @@ const HeroArea = ({ dateTime, peopleCount, onDateTimeChange, onPersonCountChange
     setIsDatePickerOpen(true);
     onDateTimeChange?.();
   }, [onDateTimeChange]);
+
+  const openGuestCounter = useCallback(() => {
+    setIsGuestModalOpen(true);
+    onPersonCountChange?.();
+  }, [onPersonCountChange]);
 
   const handleDateConfirm = useCallback(
     (dates: Date[]) => {
@@ -133,7 +141,7 @@ const HeroArea = ({ dateTime, peopleCount, onDateTimeChange, onPersonCountChange
         <div className="flex flex-col items-center">
           <div className="flex flex-col gap-3 mb-8">
             <DateTimeInput dateTime={dateTimeText} onChangeClick={openDatePicker} />
-            <PersonCountInput count={peopleCount} onChangeClick={onPersonCountChange} />
+            <PersonCountInput count={peopleCountText} onChangeClick={openGuestCounter} />
           </div>
           <div>
             <Button label="검색하기" onClick={onSearch} variant={ButtonVariant.Main} size={BtnSizeVariant.MD} />
@@ -141,7 +149,7 @@ const HeroArea = ({ dateTime, peopleCount, onDateTimeChange, onPersonCountChange
         </div>
       </div>
 
-      {(isDatePickerOpen || isTimePickerOpen) && (
+      {(isDatePickerOpen || isTimePickerOpen || isGuestModalOpen) && (
         <div className="fixed inset-0 z-50 flex justify-center items-center bg-black/80">
           {/* wrapper 기준 폭으로 중앙 정렬 */}
           <div className="w-[25.125rem] flex flex-col items-center">
@@ -154,6 +162,17 @@ const HeroArea = ({ dateTime, peopleCount, onDateTimeChange, onPersonCountChange
             )}
             {isTimePickerOpen && (
               <TimePicker onConfirm={handleTimeConfirm} onCancel={handleTimeCancel} disabled={isToastVisible} />
+            )}
+            {isGuestModalOpen && (
+              <GuestCounterModal
+                open
+                onClose={() => setIsGuestModalOpen(false)}
+                onConfirm={(val) => {
+                  setPeopleCountText(val);
+                  setIsGuestModalOpen(false);
+                }}
+                initialCount={peopleCountText}
+              />
             )}
             {/* 토스트는 모달 하단에 배치되도록 아래에 둔다 */}
             <div className="mt-3">

--- a/pick-habju/src/components/ToastMessage/ToastMessage.tsx
+++ b/pick-habju/src/components/ToastMessage/ToastMessage.tsx
@@ -1,14 +1,39 @@
+import { useEffect, useMemo, useState } from 'react';
 import { useToastStore } from '../../store/toast/toastStore';
 import Error from '../../assets/svg/error.svg';
 
 const ToastMessage = () => {
   const { message, isVisible } = useToastStore();
+  const [shouldRender, setShouldRender] = useState(false);
+  const [isExiting, setIsExiting] = useState(false);
 
-  if (!isVisible || !message) return null;
+  useEffect(() => {
+    let timeoutId: number | undefined;
+    if (isVisible && message) {
+      setIsExiting(false);
+      setShouldRender(true);
+    } else if (shouldRender) {
+      setIsExiting(true);
+      timeoutId = window.setTimeout(() => {
+        setShouldRender(false);
+        setIsExiting(false);
+      }, 200);
+    }
+    return () => {
+      if (timeoutId) window.clearTimeout(timeoutId);
+    };
+  }, [isVisible, message, shouldRender]);
+
+  const animationClass = useMemo(
+    () => (isExiting ? 'animate-[toast-out_0.2s_ease-in_forwards]' : 'animate-[toast-in_0.2s_ease-out]'),
+    [isExiting]
+  );
+
+  if (!shouldRender || !message) return null;
 
   return (
-    <div>
-      <div className="flex justify-center items-center gap-3 px-6 py-3 bg-gray-600 rounded-full  text-primary-white font-modal-default">
+    <div className="w-full flex justify-center">
+      <div className={`flex justify-center items-center gap-3 px-6 py-3 bg-gray-600 rounded-full text-primary-white font-modal-default transition-all ${animationClass}`}>
         <div>
           <img src={Error} alt="error" />
         </div>

--- a/pick-habju/src/components/ToastMessage/ToastMessageEnums.ts
+++ b/pick-habju/src/components/ToastMessage/ToastMessageEnums.ts
@@ -1,4 +1,5 @@
 export enum ReservationToastKey {
+  INVALID_TYPE = 'INVALID_TYPE',
   PAST_TIME = 'PAST_TIME',
   TOO_LONG = 'TOO_LONG',
   TOO_SHORT = 'TOO_SHORT',
@@ -6,8 +7,9 @@ export enum ReservationToastKey {
 }
 
 export const ReservationToastMessages: Record<ReservationToastKey, string> = {
+  [ReservationToastKey.INVALID_TYPE]: '올바른 시간으로 골라 주세요!',
   [ReservationToastKey.PAST_TIME]: '현재 이후 시간으로 골라 주세요!',
-  [ReservationToastKey.TOO_LONG]: '예약 시간이 조금 긴 것 같은데요,\n다시 한 번 확인해 주시겠어요?',
+  [ReservationToastKey.TOO_LONG]: '예약 시간이 조금 긴 것 같은데요,\n5시간 초과면 예약이 불가능해요!',
   [ReservationToastKey.TOO_SHORT]: '일부 공간은 1시간 예약이 제한돼요.\n2시간 이상이면 선택지가 늘어나요!',
   [ReservationToastKey.TOO_MANY_PEOPLE]: '예약 인원이 조금 많은 것 같은데요,\n다시 한 번 확인해 주시겠어요?',
 };

--- a/pick-habju/src/index.css
+++ b/pick-habju/src/index.css
@@ -285,6 +285,28 @@
     box-shadow: var(--box-shadow-search);
   }
 
+  /* Toast keyframes */
+  @keyframes toast-in {
+    0% {
+      transform: translateY(8px);
+      opacity: 0;
+    }
+    100% {
+      transform: translateY(0);
+      opacity: 1;
+    }
+  }
+  @keyframes toast-out {
+    0% {
+      transform: translateY(0);
+      opacity: 1;
+    }
+    100% {
+      transform: translateY(-8px);
+      opacity: 0;
+    }
+  }
+
   /* Time Picker Scroll */
   .scroll-picker {
     scroll-snap-type: y mandatory;

--- a/pick-habju/src/pages/HomePage.tsx
+++ b/pick-habju/src/pages/HomePage.tsx
@@ -6,13 +6,22 @@ import img3 from '../assets/images/3.png';
 
 
 const HomePage = () => {
+  const now = new Date();
+  const month = now.getMonth() + 1;
+  const day = String(now.getDate()).padStart(2, '0');
+  const weekdayKorean = ['일', '월', '화', '수', '목', '금', '토'][now.getDay()];
+  const startHour = now.getHours();
+  const rawEndHour = (startHour + 2) % 24;
+  const displayEndHour = rawEndHour === 0 ? 24 : rawEndHour <= startHour ? rawEndHour + 24 : rawEndHour;
+  const defaultDateTime = `${month}월 ${day}일 (${weekdayKorean}) ${startHour}~${displayEndHour}시`;
+  const defaultPeopleCount = 12;
 
   return (
     <div className="w-full flex flex-col items-center">
       <div className="flex w-[25.125rem] flex-col justify-center items-center">
         <HeroArea
-          dateTime={"3월 26일 (수) 18-20시"}
-          peopleCount={10}
+          dateTime={defaultDateTime}
+          peopleCount={defaultPeopleCount}
           onDateTimeChange={() => {}}
           onPersonCountChange={() => {}}
           onSearch={() => {}}

--- a/pick-habju/src/store/toast/toastStore.ts
+++ b/pick-habju/src/store/toast/toastStore.ts
@@ -18,7 +18,7 @@ export const useToastStore = create<ToastState>((set) => {
       currentTimeoutId = setTimeout(() => {
         set({ isVisible: false });
         currentTimeoutId = null;
-      }, 3000);
+      }, 900);
     },
     hideToast: () => {
       // 수동으로 닫을 때도 타이머 클리어


### PR DESCRIPTION
관련이슈
closes #23 

## 이슈내용 말고 추가적으로 알아야할 것
1.  heroArea 기본값설정:
dateTime: 현재 날짜, 현재 시각 기준 2시간 구간
예: 시스템 시간이 21시라면 “9월 03일 (수) 21~23시”,
peopleCount: 12

2. toastStore에서 3초 대신 0.9초로 줄임
+) 애니메이션추가 index.css의 toast keyframes

3. 날짜픽커모달뜰때 디폴트값 당일로 해놓음

4. 1~30까지만 선택가능
- 0명일때의 오류, 너무많은 인원일때의 오류 자동처리

5. 타임픽커에서 뒤로가기 하면 이전에 선택했던 날짜 상태로 유지되도록

**_6. 토스트메시지띄울동안은 확인버튼 비활성화시킴_**