### PR TITLE
[REFACTOR] 백엔드 api 연결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,37 +1,43 @@
-name: deploy
+name: Deploy Frontend
 
 on:
   push:
     branches: [main]
 
 jobs:
-  build:
+  build-and-deploy-frontend:
     runs-on: ubuntu-latest
-    container: pandoc/latex
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-      - name: Install mustache (to update the date)
-        run: apk add ruby && gem install mustache
+      # Node.js 환경 설정 (프론트엔드 빌드에 필수)
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20' # 프로젝트의 Node.js 버전에 맞게 설정
 
-      - name: Give build.sh execute permission
-        run: chmod +x ./pick-habju/build.sh
+      # 프론트엔드 의존성 설치
+      - name: Install frontend dependencies
+        run: npm install
 
-      - name: Run build script
-        run: ./pick-habju/build.sh
+      # 프론트엔드 빌드 단계: VITE_API_BASE_URL 환경 변수 주입
+      - name: Build frontend
+        run: npm run build
+        env:
+          # ***** 여기가 PM이 말한 "백엔드 URL을 작성하는 작업"의 핵심 부분입니다. *****
+          # 이 값은 빌드된 프론트엔드 코드에 포함되어 API 호출에 사용됩니다.
+          VITE_API_BASE_URL: http://3.39.13.6:8000 # EC2 백엔드 API 주소로 변경
 
-      - name: Pushes to another repository
-        id: push_directory
+      # 빌드된 결과물을 pick-habju-frontend 저장소로 푸시
+      - name: Pushes build output to pick-habju-frontend repository
         uses: cpina/github-action-push-to-another-repository@main
         env:
           API_TOKEN_GITHUB: ${{ secrets.AUTO_ACTIONS }}
         with:
-          source-directory: "output"
+          source-directory: "output" # Vite의 기본 빌드 출력 폴더 (확인 필요)
           destination-github-username: S-Gihun
           destination-repository-name: pick-habju-frontend
           user-email: ${{ secrets.EMAIL }}
-          commit-message: ${{ github.event.commits[0].message }}
+          commit-message: "Feat: Deploy frontend from backend build job [skip ci]"
           target-branch: main
-
-      - name: Test get variable exported by push-to-another-repository
-        run: echo $DESTINATION_CLONED_DIRECTORY

--- a/pick-habju/.env.dev
+++ b/pick-habju/.env.dev
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL = 'http://3.39.13.6:8000'

--- a/pick-habju/.env.dev
+++ b/pick-habju/.env.dev
@@ -1,1 +1,2 @@
+
 VITE_API_BASE_URL = 'http://3.39.13.6:8000'

--- a/pick-habju/.env.dev
+++ b/pick-habju/.env.dev
@@ -1,2 +1,0 @@
-
-VITE_API_BASE_URL = 'http://3.39.13.6:8000'

--- a/pick-habju/.gitignore
+++ b/pick-habju/.gitignore
@@ -25,5 +25,8 @@ dist-ssr
 
 .vercel
 .env
+.env*.local
+.env.*
+!.env.example
 
 *storybook.log

--- a/pick-habju/src/api/apiClient.ts
+++ b/pick-habju/src/api/apiClient.ts
@@ -1,5 +1,6 @@
 export const apiBaseUrl = (() => {
   const envUrl = import.meta.env?.VITE_API_BASE_URL as string | undefined;
+  console.log(import.meta.env.MODE, import.meta.env.VITE_API_BASE_URL);
   return envUrl ?? 'http://localhost:8000';
 })();
 


### PR DESCRIPTION
## 관련 이슈
closes #34 

## 내용
.env.dev 파일에 VITE_API_BASE_URL 를 명시하여 import.meta.env?.VITE_API_BASE_URL이 사용할 수 있게 함.
기존 워크플로우가 프론트엔드 배포에 맞지 않는 내용이라 전면 수정함.

(이게 얼마나 작업됐고 또 알맞게 된건지 모르겠어서 공부해봤는데 여전히 잘 모르겠음.. 3달전 커밋내용인거보면 프레임워크만 붙여넣기 한거같음. 내일 디코로 물어볼거 물어보고 더 작업해보겠음)