### PR TITLE
[HOTFIX] 출시전 피드백 반영+반응형디자인 야매적용

### DIFF
--- a/pick-habju/index.html
+++ b/pick-habju/index.html
@@ -12,7 +12,7 @@
     </script>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>합주할 땐 픽합주</title>
   </head>
   <body>

--- a/pick-habju/src/components/Card/Card.tsx
+++ b/pick-habju/src/components/Card/Card.tsx
@@ -166,6 +166,9 @@ const Card = ({
             alt={`slide ${current + 1}`}
             className="w-full h-full object-cover cursor-pointer"
             style={{ animation: `${direction === 'right' ? 'slide-right' : 'slide-left'} 0.35s ease-out` }}
+            loading="lazy"
+            decoding="async"
+            fetchPriority="low"
           />
         </div>
         {renderHeader()}

--- a/pick-habju/src/components/Footer/Footer.tsx
+++ b/pick-habju/src/components/Footer/Footer.tsx
@@ -1,7 +1,7 @@
 const Footer = () => {
   return (
     <div
-      className="flex w-[25.125rem] h-[9.3125rem] pt-[1.25rem] pr-[2.03125rem] pb-[3.6875rem] pl-[2.03125rem] flex-col items-center bg-[#FFFBF0]"
+      className="flex w-full max-w-[25.125rem] h-[9.3125rem] pt-[1.25rem] pr-[2.03125rem] pb-[3.6875rem] pl-[2.03125rem] flex-col items-center bg-[#FFFBF0]"
       aria-label="사이트 푸터"
     >
       <div className="flex items-center text-gray-400 font-footer-button">

--- a/pick-habju/src/components/Footer/Footer.tsx
+++ b/pick-habju/src/components/Footer/Footer.tsx
@@ -1,7 +1,7 @@
 const Footer = () => {
   return (
     <div
-      className="flex w-full max-w-[25.125rem] h-[9.3125rem] pt-[1.25rem] pr-[2.03125rem] pb-[3.6875rem] pl-[2.03125rem] flex-col items-center bg-[#FFFBF0]"
+      className="flex w-full max-w-[25.9375rem] h-[9.3125rem] pt-[1.25rem] pr-[2.03125rem] pb-[3.6875rem] pl-[2.03125rem] flex-col items-center bg-[#FFFBF0]"
       aria-label="사이트 푸터"
     >
       <div className="flex items-center text-gray-400 font-footer-button">

--- a/pick-habju/src/components/Header/AppHeader.tsx
+++ b/pick-habju/src/components/Header/AppHeader.tsx
@@ -2,7 +2,7 @@ import HeaderLogo from './HeaderLogo';
 
 const LogoHeader = () => (
   <div
-    className="flex items-center self-stretch bg-primary-white py-[0.375rem] pr-[16.31088rem]"
+    className="flex items-center self-stretch bg-primary-white py-[0.375rem] pr-4"
     aria-label="Logo Header"
   >
     <HeaderLogo />
@@ -11,8 +11,8 @@ const LogoHeader = () => (
 
 const AppHeader = () => {
   return (
-    <div className="flex w-[25.125rem] justify-center items-center">
-      <div className="flex flex-col w-full">
+    <div className="flex w-full justify-center items-center">
+      <div className="flex flex-col w-full max-w-[25.125rem]">
         <LogoHeader />
       </div>
     </div>

--- a/pick-habju/src/components/Header/AppHeader.tsx
+++ b/pick-habju/src/components/Header/AppHeader.tsx
@@ -12,7 +12,7 @@ const LogoHeader = () => (
 const AppHeader = () => {
   return (
     <div className="flex w-full justify-center items-center">
-      <div className="flex flex-col w-full max-w-[25.125rem]">
+      <div className="flex flex-col w-full max-w-[25.9375rem]">
         <LogoHeader />
       </div>
     </div>

--- a/pick-habju/src/components/HeroArea/HeroArea.tsx
+++ b/pick-habju/src/components/HeroArea/HeroArea.tsx
@@ -315,7 +315,7 @@ const HeroArea = ({ dateTime, peopleCount, onDateTimeChange, onPersonCountChange
       {(isDatePickerOpen || isTimePickerOpen || isGuestModalOpen) && (
         <div className="fixed inset-0 z-50 flex justify-center items-center bg-black/80" onClick={handleOverlayClick}>
           {/* wrapper 기준 폭으로 중앙 정렬 */}
-          <div className="relative w-[25.125rem] flex flex-col items-center">
+          <div className="relative w-full max-w-[25.125rem] flex flex-col items-center">
             {isDatePickerOpen && (
               <DatePicker
                 onConfirm={handleDateConfirm}

--- a/pick-habju/src/components/HeroArea/HeroArea.tsx
+++ b/pick-habju/src/components/HeroArea/HeroArea.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import Button from '../Button/Button';
 import { BtnSizeVariant, ButtonVariant } from '../Button/ButtonEnums';
 import PersonCountInput from './Input/Person/PersonCountInput';
@@ -222,6 +222,29 @@ const HeroArea = ({ dateTime, peopleCount, onDateTimeChange, onPersonCountChange
     setIsTimePickerOpen(false);
     setIsDatePickerOpen(true);
   }, []);
+
+  // 오버레이 바깥 클릭으로 모달 닫기
+  const handleOverlayClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target !== e.currentTarget) return;
+    setIsDatePickerOpen(false);
+    setIsTimePickerOpen(false);
+    setIsGuestModalOpen(false);
+  }, []);
+
+  // ESC 키로 모달 닫기
+  useEffect(() => {
+    if (!(isDatePickerOpen || isTimePickerOpen || isGuestModalOpen)) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        setIsDatePickerOpen(false);
+        setIsTimePickerOpen(false);
+        setIsGuestModalOpen(false);
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [isDatePickerOpen, isTimePickerOpen, isGuestModalOpen]);
   return (
     <div
       className="relative w-full h-97.5 flex flex-col items-center"
@@ -290,7 +313,7 @@ const HeroArea = ({ dateTime, peopleCount, onDateTimeChange, onPersonCountChange
       </div>
 
       {(isDatePickerOpen || isTimePickerOpen || isGuestModalOpen) && (
-        <div className="fixed inset-0 z-50 flex justify-center items-center bg-black/80">
+        <div className="fixed inset-0 z-50 flex justify-center items-center bg-black/80" onClick={handleOverlayClick}>
           {/* wrapper 기준 폭으로 중앙 정렬 */}
           <div className="relative w-[25.125rem] flex flex-col items-center">
             {isDatePickerOpen && (

--- a/pick-habju/src/components/HeroArea/HeroArea.tsx
+++ b/pick-habju/src/components/HeroArea/HeroArea.tsx
@@ -315,7 +315,7 @@ const HeroArea = ({ dateTime, peopleCount, onDateTimeChange, onPersonCountChange
       {(isDatePickerOpen || isTimePickerOpen || isGuestModalOpen) && (
         <div className="fixed inset-0 z-50 flex justify-center items-center bg-black/80" onClick={handleOverlayClick}>
           {/* wrapper 기준 폭으로 중앙 정렬 */}
-          <div className="relative w-full max-w-[25.125rem] flex flex-col items-center">
+          <div className="relative w-full max-w-[25.9375rem] flex flex-col items-center">
             {isDatePickerOpen && (
               <DatePicker
                 onConfirm={handleDateConfirm}

--- a/pick-habju/src/components/HeroArea/Input/Date/DateTimeInput.tsx
+++ b/pick-habju/src/components/HeroArea/Input/Date/DateTimeInput.tsx
@@ -1,16 +1,28 @@
 import CalendarIcon from '../../../../assets/svg/calendarIcon.svg';
+import type { KeyboardEvent } from 'react';
 import type { DateTimeInputProps } from './DateTimeInput.types';
 
 const DateTimeInput = ({ dateTime, onChangeClick }: DateTimeInputProps) => {
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onChangeClick();
+    }
+  };
   return (
-    <div className="w-70 h-14 rounded-lg bg-primary-white flex items-center justify-between px-3.5">
+    <div
+      className="w-70 h-14 rounded-lg bg-primary-white flex items-center justify-between px-3.5 cursor-pointer select-none"
+      role="button"
+      tabIndex={0}
+      aria-label="날짜/시간 변경"
+      onClick={onChangeClick}
+      onKeyDown={handleKeyDown}
+    >
       <div className="flex items-center justify-center text-primary-black font-hero-info gap-2">
         <img src={CalendarIcon} alt="Calendar Icon" />
         <p>{dateTime}</p>
       </div>
-      <button onClick={onChangeClick} className="text-blue-500 px-3 py-4 font-hero-edit underline">
-        변경
-      </button>
+      <span className="text-blue-500 px-3 py-4 font-hero-edit underline">변경</span>
     </div>
   );
 };

--- a/pick-habju/src/components/HeroArea/Input/Person/PersonCountInput.tsx
+++ b/pick-habju/src/components/HeroArea/Input/Person/PersonCountInput.tsx
@@ -1,16 +1,28 @@
 import GuestIcon from '../../../../assets/svg/guestIcon.svg';
+import type { KeyboardEvent } from 'react';
 import type { PersonCountInputProps } from './PersonCountInput.types';
 
 const PersonCountInput = ({ count, onChangeClick }: PersonCountInputProps) => {
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onChangeClick();
+    }
+  };
   return (
-    <div className="w-70 h-14 rounded-lg bg-primary-white flex items-center justify-between px-3.5">
+    <div
+      className="w-70 h-14 rounded-lg bg-primary-white flex items-center justify-between px-3.5 cursor-pointer select-none"
+      role="button"
+      tabIndex={0}
+      aria-label="인원 변경"
+      onClick={onChangeClick}
+      onKeyDown={handleKeyDown}
+    >
       <div className="flex items-center justify-center text-primary-black font-hero-info gap-2">
         <img src={GuestIcon} alt="Guest Icon" />
         <p>인원 {count}명</p>
       </div>
-      <button onClick={onChangeClick} className="text-blue-500 px-3 py-4 font-hero-edit underline">
-        변경
-      </button>
+      <span className="text-blue-500 px-3 py-4 font-hero-edit underline">변경</span>
     </div>
   );
 };

--- a/pick-habju/src/components/Modal/Book/BookModal.tsx
+++ b/pick-habju/src/components/Modal/Book/BookModal.tsx
@@ -42,7 +42,7 @@ const BookModalStepper = ({ room, dateIso, hourSlots, peopleCount, finalTotalFro
   // 바깥 클릭 닫기는 ModalOverlay에서 처리
 
   return (
-      <div className="w-full max-w-[25.125rem]" onClick={(e) => e.stopPropagation()}>
+      <div className="w-full max-w-[25.9375rem]" onClick={(e) => e.stopPropagation()}>
         {step === 1 && (
           <BookStepCalculationModal
             basicAmount={breakdown.basicAmount}

--- a/pick-habju/src/components/Modal/Book/BookModal.tsx
+++ b/pick-habju/src/components/Modal/Book/BookModal.tsx
@@ -42,7 +42,7 @@ const BookModalStepper = ({ room, dateIso, hourSlots, peopleCount, finalTotalFro
   // 바깥 클릭 닫기는 ModalOverlay에서 처리
 
   return (
-      <div className="w-[25.125rem]" onClick={(e) => e.stopPropagation()}>
+      <div className="w-full max-w-[25.125rem]" onClick={(e) => e.stopPropagation()}>
         {step === 1 && (
           <BookStepCalculationModal
             basicAmount={breakdown.basicAmount}

--- a/pick-habju/src/components/Modal/Call/CallReservationNoticeModal.tsx
+++ b/pick-habju/src/components/Modal/Call/CallReservationNoticeModal.tsx
@@ -15,7 +15,7 @@ const CallReservationNoticeModal = ({ open, onClose, studioName, phoneNumber }: 
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80" aria-modal="true" role="dialog">
-      <div className="w-[25.125rem] flex flex-col items-center translate-x-6">
+      <div className="w-full max-w-[25.125rem] flex flex-col items-center">
         <div className="w-[22.5rem] rounded-[0.5rem] bg-primary-white flex flex-col items-end gap-3 py-[3.5rem] px-[1.75rem]">
           {/* 1. 안내 문구 */}
           <div className="w-full text-center font-modal-default text-primary-black">

--- a/pick-habju/src/components/Modal/Call/CallReservationNoticeModal.tsx
+++ b/pick-habju/src/components/Modal/Call/CallReservationNoticeModal.tsx
@@ -15,7 +15,7 @@ const CallReservationNoticeModal = ({ open, onClose, studioName, phoneNumber }: 
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80" aria-modal="true" role="dialog">
-      <div className="w-full max-w-[25.125rem] flex flex-col items-center">
+      <div className="w-full max-w-[25.9375rem] flex flex-col items-center">
         <div className="w-[22.5rem] rounded-[0.5rem] bg-primary-white flex flex-col items-end gap-3 py-[3.5rem] px-[1.75rem]">
           {/* 1. 안내 문구 */}
           <div className="w-full text-center font-modal-default text-primary-black">

--- a/pick-habju/src/components/Modal/ImageCarouselModal.tsx
+++ b/pick-habju/src/components/Modal/ImageCarouselModal.tsx
@@ -63,7 +63,7 @@ const ImageCarouselModal = ({ images, initialIndex = 0, onClose, closeIconSrc }:
   return (
     <div ref={overlayRef} onClick={handleOverlayClick} className="fixed inset-0 z-50 flex justify-center items-center bg-black/80">
       {/* 컨테이너: wrapper 폭 기준 중앙 */}
-      <div className="w-[25.125rem]">
+      <div className="w-full max-w-[25.125rem]">
         {/* Close 버튼 영역 (오른쪽 정렬) */}
         <div className="w-full flex justify-end">
           <button
@@ -83,7 +83,7 @@ const ImageCarouselModal = ({ images, initialIndex = 0, onClose, closeIconSrc }:
         {/* Group */}
         <div className="h-[16.25rem] self-stretch flex flex-col items-center">
           {/* Rectangle (이미지 프레임 고정) */}
-          <div className="relative w-[23.125rem] h-[16.25rem] flex-shrink-0 rounded-[0.75rem] overflow-hidden">
+          <div className="relative w-full h-[16.25rem] flex-shrink-0 rounded-[0.75rem] overflow-hidden">
             {/* 이미지 레이어만 슬라이드 */}
             <div
               key={animKey}
@@ -98,7 +98,7 @@ const ImageCarouselModal = ({ images, initialIndex = 0, onClose, closeIconSrc }:
             />
 
             {/* 컨트롤 오버레이 (고정) */}
-            <div className="absolute inset-0 flex w-[23.125rem] h-[16.25rem] flex-col justify-between items-start">
+            <div className="absolute inset-0 flex w-full h-[16.25rem] flex-col justify-between items-start">
               {/* Chevron Row */}
               <div className="flex pt-[6.25rem] justify-between items-center self-stretch px-0">
                 <Chevron variant={variant} onPrev={prev} onNext={next} containerClassName="w-full" />

--- a/pick-habju/src/components/Modal/ImageCarouselModal.tsx
+++ b/pick-habju/src/components/Modal/ImageCarouselModal.tsx
@@ -63,7 +63,7 @@ const ImageCarouselModal = ({ images, initialIndex = 0, onClose, closeIconSrc }:
   return (
     <div ref={overlayRef} onClick={handleOverlayClick} className="fixed inset-0 z-50 flex justify-center items-center bg-black/80">
       {/* 컨테이너: wrapper 폭 기준 중앙 */}
-      <div className="w-full max-w-[25.125rem]">
+      <div className="w-full max-w-[25.9375rem]">
         {/* Close 버튼 영역 (오른쪽 정렬) */}
         <div className="w-full flex justify-end">
           <button

--- a/pick-habju/src/components/Modal/OneHour/OneHourCallReservationNoticeModal.tsx
+++ b/pick-habju/src/components/Modal/OneHour/OneHourCallReservationNoticeModal.tsx
@@ -27,7 +27,7 @@ const OneHourCallReservationNoticeModal = ({ open, onClose, studioName, phoneNum
       aria-modal="true"
       role="dialog"
     >
-      <div className="w-full max-w-[25.125rem] flex flex-col items-center">
+      <div className="w-full max-w-[25.9375rem] flex flex-col items-center">
         {/* 본문 카드 */}
         <div className="w-full max-w-[22.5rem] rounded-[0.5rem] bg-primary-white flex flex-col items-center gap-4 py-[2.25rem] px-[1.75rem]">
           {/* 1. 헤드 문구 (3줄) */}

--- a/pick-habju/src/components/Modal/OneHour/OneHourCallReservationNoticeModal.tsx
+++ b/pick-habju/src/components/Modal/OneHour/OneHourCallReservationNoticeModal.tsx
@@ -27,9 +27,9 @@ const OneHourCallReservationNoticeModal = ({ open, onClose, studioName, phoneNum
       aria-modal="true"
       role="dialog"
     >
-      <div className="w-[25.125rem] flex flex-col items-center">
+      <div className="w-full max-w-[25.125rem] flex flex-col items-center">
         {/* 본문 카드 */}
-        <div className="w-[22.5rem] rounded-[0.5rem] bg-primary-white flex flex-col items-center gap-4 py-[2.25rem] px-[1.75rem]">
+        <div className="w-full max-w-[22.5rem] rounded-[0.5rem] bg-primary-white flex flex-col items-center gap-4 py-[2.25rem] px-[1.75rem]">
           {/* 1. 헤드 문구 (3줄) */}
           <div className="flex flex-col items-center gap-2 self-stretch">
             <div className="text-center font-modal-default text-primary-black">해당 합주실은 앞뒤로 예약이 있을 때<br></br>중간에 남은 1시간만 <span className="text-blue-500 font-modal-default">전화</span>로 가능합니다.</div>
@@ -42,7 +42,7 @@ const OneHourCallReservationNoticeModal = ({ open, onClose, studioName, phoneNum
           </div>
 
           {/* 버튼 영역 */}
-          <div className="flex w-[18.375rem] justify-center items-center gap-3">
+          <div className="flex w-full max-w-[18.375rem] justify-center items-center gap-3">
             {/* 다시 고를게요 */}
             <button
               type="button"

--- a/pick-habju/src/components/Modal/Portion/PartialReservationConfirmModal.tsx
+++ b/pick-habju/src/components/Modal/Portion/PartialReservationConfirmModal.tsx
@@ -27,7 +27,7 @@ const PartialReservationConfirmModal = ({ open, onClose, availableTime, onConfir
       aria-modal="true"
       role="dialog"
     >
-      <div className="w-full max-w-[25.125rem] flex flex-col items-center">
+      <div className="w-full max-w-[25.9375rem] flex flex-col items-center">
         {/* 본문 카드 */}
         <div className="w-full max-w-[22.5rem] rounded-[0.5rem] bg-primary-white flex flex-col items-center gap-4 py-[2.25rem] px-[1.75rem]">
           {/* 1. 헤드 문구 */}

--- a/pick-habju/src/components/Modal/Portion/PartialReservationConfirmModal.tsx
+++ b/pick-habju/src/components/Modal/Portion/PartialReservationConfirmModal.tsx
@@ -27,9 +27,9 @@ const PartialReservationConfirmModal = ({ open, onClose, availableTime, onConfir
       aria-modal="true"
       role="dialog"
     >
-      <div className="w-[25.125rem] flex flex-col items-center">
+      <div className="w-full max-w-[25.125rem] flex flex-col items-center">
         {/* 본문 카드 */}
-        <div className="w-[22.5rem] rounded-[0.5rem] bg-primary-white flex flex-col items-center gap-4 py-[2.25rem] px-[1.75rem]">
+        <div className="w-full max-w-[22.5rem] rounded-[0.5rem] bg-primary-white flex flex-col items-center gap-4 py-[2.25rem] px-[1.75rem]">
           {/* 1. 헤드 문구 */}
           <div className="flex flex-col items-center gap-4 self-stretch">
             <div className="text-center font-modal-default text-primary-black">
@@ -46,7 +46,7 @@ const PartialReservationConfirmModal = ({ open, onClose, availableTime, onConfir
           </div>
 
           {/* 버튼 영역 */}
-          <div className="flex w-[18.375rem] justify-center items-center gap-3">
+          <div className="flex w-full max-w-[18.375rem] justify-center items-center gap-3">
             {/* 다시 고를게요 */}
             <button
               type="button"

--- a/pick-habju/src/components/Search/BeforeSearchView.tsx
+++ b/pick-habju/src/components/Search/BeforeSearchView.tsx
@@ -3,7 +3,7 @@ import BeforeSearchSvg from '../../assets/svg/BeforeSearch.svg';
 const BeforeSearchView = () => {
   return (
     <div
-      className="flex w-full max-w-[25.125rem] flex-col justify-center items-start bg-[#FFFBF0]"
+      className="flex w-full max-w-[25.9375rem] flex-col justify-center items-start bg-[#FFFBF0]"
       aria-label="Before Search Section"
     >
       <div

--- a/pick-habju/src/components/Search/BeforeSearchView.tsx
+++ b/pick-habju/src/components/Search/BeforeSearchView.tsx
@@ -3,11 +3,11 @@ import BeforeSearchSvg from '../../assets/svg/BeforeSearch.svg';
 const BeforeSearchView = () => {
   return (
     <div
-      className="flex w-[25.125rem] flex-col justify-center items-start bg-[#FFFBF0]"
+      className="flex w-full max-w-[25.125rem] flex-col justify-center items-start bg-[#FFFBF0]"
       aria-label="Before Search Section"
     >
       <div
-        className="flex w-[25.125rem] h-[16.5625rem] pt-[4.06513rem] pr-[3.625rem] pb-[4.12238rem] pl-[3.625rem] justify-center items-center"
+        className="flex w-full h-[16.5625rem] pt-[4.06513rem] pr-[3.625rem] pb-[4.12238rem] pl-[3.625rem] justify-center items-center"
         aria-label="Before Search Illustration Wrapper"
       >
         <img src={BeforeSearchSvg} alt="Before Search Illustration" />

--- a/pick-habju/src/components/Search/DefaultView.tsx
+++ b/pick-habju/src/components/Search/DefaultView.tsx
@@ -131,7 +131,7 @@ const DefaultView = () => {
             />
             {openIdx === i && lastQuery && (
               <ModalOverlay open onClose={() => setOpenIdx(null)}>
-                <div className="w-full max-w-[25.125rem]" onClick={(e) => e.stopPropagation()}>
+                <div className="w-full max-w-[25.9375rem]" onClick={(e) => e.stopPropagation()}>
                   <BookModalStepper
                   room={room}
                   dateIso={lastQuery.date}
@@ -218,7 +218,7 @@ const DefaultView = () => {
           case 'sameDayCall':
             return (
               <ModalOverlay open onClose={closeModal}>
-                <div className="w-full max-w-[25.125rem]" onClick={(e) => e.stopPropagation()}>
+                <div className="w-full max-w-[25.9375rem]" onClick={(e) => e.stopPropagation()}>
                   <CallReservationNoticeModal
                     open
                     onClose={closeModal}

--- a/pick-habju/src/components/Search/DefaultView.tsx
+++ b/pick-habju/src/components/Search/DefaultView.tsx
@@ -131,7 +131,7 @@ const DefaultView = () => {
             />
             {openIdx === i && lastQuery && (
               <ModalOverlay open onClose={() => setOpenIdx(null)}>
-                <div className="w-[25.125rem] transform translate-x-6.5" onClick={(e) => e.stopPropagation()}>
+                <div className="w-full max-w-[25.125rem]" onClick={(e) => e.stopPropagation()}>
                   <BookModalStepper
                   room={room}
                   dateIso={lastQuery.date}
@@ -218,7 +218,7 @@ const DefaultView = () => {
           case 'sameDayCall':
             return (
               <ModalOverlay open onClose={closeModal}>
-                <div className="w-[25.125rem] transform -translate-x-6.5" onClick={(e) => e.stopPropagation()}>
+                <div className="w-full max-w-[25.125rem]" onClick={(e) => e.stopPropagation()}>
                   <CallReservationNoticeModal
                     open
                     onClose={closeModal}

--- a/pick-habju/src/components/Search/NoResultView.tsx
+++ b/pick-habju/src/components/Search/NoResultView.tsx
@@ -3,7 +3,7 @@ import NoResultSvg from '../../assets/svg/NoResult.svg';
 const NoResultView = () => {
   return (
     <div
-      className="flex w-full max-w-[25.125rem] flex-col justify-center items-start bg-[#FFFBF0]"
+      className="flex w-full max-w-[25.9375rem] flex-col justify-center items-start bg-[#FFFBF0]"
       aria-label="No Result Section"
     >
       <div

--- a/pick-habju/src/components/Search/NoResultView.tsx
+++ b/pick-habju/src/components/Search/NoResultView.tsx
@@ -3,11 +3,11 @@ import NoResultSvg from '../../assets/svg/NoResult.svg';
 const NoResultView = () => {
   return (
     <div
-      className="flex w-[25.125rem] flex-col justify-center items-start bg-[#FFFBF0]"
+      className="flex w-full max-w-[25.125rem] flex-col justify-center items-start bg-[#FFFBF0]"
       aria-label="No Result Section"
     >
       <div
-        className="flex w-[25.125rem] h-[16.5625rem] pt-[4.06513rem] pr-[3.625rem] pb-[4.12238rem] pl-[3.625rem] justify-center items-center"
+        className="flex w-full h-[16.5625rem] pt-[4.06513rem] pr-[3.625rem] pb-[4.12238rem] pl-[3.625rem] justify-center items-center"
         aria-label="No Result Illustration Wrapper"
       >
         <img src={NoResultSvg} alt="No Result Illustration" />

--- a/pick-habju/src/index.css
+++ b/pick-habju/src/index.css
@@ -4,6 +4,14 @@
 @import 'tailwindcss/theme' layer(theme);
 @import 'tailwindcss/utilities' layer(utilities);
 
+@layer base {
+  html, body, #root {
+    width: 100%;
+    max-width: 100%;
+    overflow-x: hidden;
+  }
+}
+
 @layer theme {
   @theme {
     --font-sans: 'Pretendard', 'Inter', sans-serif;

--- a/pick-habju/src/layout/AppWrapper.tsx
+++ b/pick-habju/src/layout/AppWrapper.tsx
@@ -9,14 +9,14 @@ type AppWrapperProps = { children?: ReactNode };
  */
 const AppWrapper = ({ children }: AppWrapperProps) => {
   return (
-    <div className="min-h-screen w-full flex justify-center bg-primary-white">
-      {/* 고정 폭 컨테이너 (디자인 기준 25.125rem → 402px 기준 확장) */}
-      <div className="w-[26rem] h-screen flex flex-col bg-primary-white">
+    <div className="min-h-screen w-full overflow-x-hidden flex justify-center bg-primary-white">
+      {/* 컨테이너: 모바일은 100% 폭, 넓은 화면에서는 중앙 정렬 최대폭 */}
+      <div className="w-full max-w-[26rem] h-screen flex flex-col bg-primary-white">
         {/* 헤더(세이프 에어리어 + 로고 헤더) */}
         <AppHeader />
 
         {/* 스크롤 영역: 헤더 제외 나머지 */}
-        <div className="flex-1 overflow-y-auto flex flex-col items-center bg-[#FFFBF0]">
+        <div className="flex-1 overflow-y-auto overflow-x-hidden flex flex-col items-center bg-[#FFFBF0]">
           <div className="w-full flex flex-col items-center">
             {children}
           </div>

--- a/pick-habju/src/layout/AppWrapper.tsx
+++ b/pick-habju/src/layout/AppWrapper.tsx
@@ -11,7 +11,7 @@ const AppWrapper = ({ children }: AppWrapperProps) => {
   return (
     <div className="min-h-screen w-full overflow-x-hidden flex justify-center bg-primary-white">
       {/* 컨테이너: 모바일은 100% 폭, 넓은 화면에서는 중앙 정렬 최대폭 */}
-      <div className="w-full max-w-[26rem] h-screen flex flex-col bg-primary-white">
+      <div className="w-full max-w-[25.9375rem] h-screen flex flex-col bg-primary-white">
         {/* 헤더(세이프 에어리어 + 로고 헤더) */}
         <AppHeader />
 

--- a/pick-habju/src/pages/HomePage.tsx
+++ b/pick-habju/src/pages/HomePage.tsx
@@ -157,7 +157,7 @@ const HomePage = () => {
 
   return (
     <div className="w-full flex flex-col items-center">
-      <div className="flex w-[25.125rem] flex-col justify-center items-center bg-primary-white">
+      <div className="flex w-full max-w-[25.125rem] flex-col justify-center items-center bg-primary-white">
         <HeroArea
           key={heroResetCounter}
           dateTime={{ label: defaultDateTimeLabel, date: defaultDateIso, hour_slots: defaultSlots }}

--- a/pick-habju/src/pages/HomePage.tsx
+++ b/pick-habju/src/pages/HomePage.tsx
@@ -157,7 +157,7 @@ const HomePage = () => {
 
   return (
     <div className="w-full flex flex-col items-center">
-      <div className="flex w-full max-w-[25.125rem] flex-col justify-center items-center bg-primary-white">
+      <div className="flex w-full max-w-[25.9375rem] flex-col justify-center items-center bg-primary-white">
         <HeroArea
           key={heroResetCounter}
           dateTime={{ label: defaultDateTimeLabel, date: defaultDateIso, hour_slots: defaultSlots }}


### PR DESCRIPTION
## 관련이슈
closes #39

## 공유하고싶은 사항
안드를 위한 반응형디자인
일단, 급하게 고쳐야했기때문에 
1. heroarea부분자체를 늘리고 안드보다 가로가 좁은 ios는 그에 맞춰 알아서 작아지는 방식
2. 사용자화면기준 꽉차게 함
3. 가로 스크롤제어

## 이슈에 적힌거말고 추가적으로 구현한 사항
1. 날짜타임, 인원 픽커 esc키랑 픽커모달 바깥부분클릭하면 창 끌 수 있음
2. 이미지 네트워크 병목사항 개선(자세한건 커밋확인필요) -> 커밋에 추후확장방향생각해둠
