### PR TITLE
[#55]; hotfix: 시간비교가 아니라 분단위 비교로 변경

### DIFF
--- a/pick-habju/src/components/HeroArea/HeroArea.tsx
+++ b/pick-habju/src/components/HeroArea/HeroArea.tsx
@@ -135,8 +135,13 @@ const HeroArea = ({ dateTime, peopleCount, onDateTimeChange, onPersonCountChange
           selectedDate.getMonth() === now.getMonth() &&
           selectedDate.getDate() === now.getDate();
         if (isSameDay) {
-          const currentHour24 = now.getHours();
-          if (start24 < currentHour24) return ReservationToastKey.PAST_TIME;
+          // 정확한 시간 비교를 위해 Date 객체 생성 (분 단위까지 고려)
+          const selectedDateTime = new Date(selectedDate);
+          selectedDateTime.setHours(start24, 0, 0, 0); // 선택한 시간으로 설정
+
+          if (now.getTime() > selectedDateTime.getTime()) {
+            return ReservationToastKey.PAST_TIME;
+          }
         }
       }
 


### PR DESCRIPTION
<!-- 이슈번호를 작성해주세요 -->
Closes #55

## 특이사항
<!-- 구현 시 고려한 사항이나 주의점이 있다면 작성해주세요 -->
- PAST_TIME 분단위 비교로 변경

   - 단순히 getHours의 숫자로 비교하게 되면 12시는 1시보다 빠른시간인데 숫자가 큼 
   - 근데 숫자가 크다는 이유로 start24는 1이고, currentHour24는 12라 과거로 판단되는 심각한 오류
   - 원래는 등호를 추가해서 pastHour=true되는 조건을 startHour <= currentHour이렇게 두려했는데 위에서 설명한 12, 1시라는 특수한 상황때문에 date객체를 도입

=> date객체를 활용해야해서 분단위로 비교해야함