### PR TITLE
[#74]; fix: 시간 표기 통일화

### DIFF
--- a/pick-habju/package.json
+++ b/pick-habju/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "classnames": "^2.5.1",
+    "date-fns": "^4.1.0",
     "framer-motion": "^12.23.12",
     "immer": "^10.1.1",
     "lucide-react": "^0.510.0",

--- a/pick-habju/src/utils/formatReservationLabel.ts
+++ b/pick-habju/src/utils/formatReservationLabel.ts
@@ -1,18 +1,30 @@
+import { parseISO, format, addHours } from 'date-fns';
+import { ko } from 'date-fns/locale';
+
+/**
+ * 선택된 시간 슬롯들의 시작과 끝을 기준으로 예약 레이블을 생성합니다.
+ * (예: ['14:00', '17:00'] 선택 시 "14~18시"로 표시)
+ * @param dateIso - 'YYYY-MM-DD' 형식의 날짜 문자열
+ * @param hourSlots - ['HH:00', ...] 형식의 시간 슬롯 배열
+ * @returns 포맷팅된 예약 시간 레이블 문자열
+ */
 export const formatReservationLabel = (dateIso: string, hourSlots: string[]): string => {
-  if (!dateIso || hourSlots.length === 0) return '';
-  const [year, monthStr, dayStr] = dateIso.split('-');
-  const month = parseInt(monthStr, 10);
-  const day = dayStr.padStart(2, '0');
-  const dateObj = new Date(parseInt(year, 10), month - 1, parseInt(dayStr, 10));
-  const weekdayKorean = ['일', '월', '화', '수', '목', '금', '토'][dateObj.getDay()];
+  if (!dateIso || !hourSlots || hourSlots.length === 0) {
+    return '';
+  }
 
-  // 시작/종료 시간 계산
-  const first = hourSlots[0];
-  const last = hourSlots[hourSlots.length - 1];
-  const startHour = parseInt(first.split(':')[0], 10);
-  const endHourBase = parseInt(last.split(':')[0], 10) + 1;
-  // 0시는 24시로 표기
-  const endHour = endHourBase === 0 ? 24 : endHourBase;
+  const dateObj = parseISO(dateIso);
+  const datePart = format(dateObj, 'M월 d일 (E)', { locale: ko });
 
-  return `${month}월 ${day}일 (${weekdayKorean}) ${startHour}~${endHour}시`;
+  // 시작 시간 계산 (가장 빠른 슬롯)
+  const firstSlot = hourSlots[0];
+  const startTime = parseISO(`${dateIso}T${firstSlot}`);
+
+  // 종료 시간 계산 (가장 늦은 슬롯 + 1시간)
+  const lastSlot = hourSlots[hourSlots.length - 1];
+  const endTime = addHours(parseISO(`${dateIso}T${lastSlot}`), 1);
+
+  const timePart = `${format(startTime, 'HH')}~${format(endTime, 'HH')}시`;
+
+  return `${datePart} ${timePart}`;
 };

--- a/pick-habju/yarn.lock
+++ b/pick-habju/yarn.lock
@@ -1992,6 +1992,11 @@ csstype@^3.0.2:
   resolved "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
+date-fns@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.1.0.tgz#64b3d83fff5aa80438f5b1a633c2e83b8a1c2d14"
+  integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
+
 debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5, debug@^4.4.0:
   version "4.4.0"
   resolved "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz"


### PR DESCRIPTION
<!-- 이슈번호를 작성해주세요 -->
Closes #74 

## 특이사항
<!-- 구현 시 고려한 사항이나 주의점이 있다면 작성해주세요 -->
- date-fns 라이브러리 도입
- 새벽 1시, 2시 등 한 자리 수 시간 표기 => 01시, 02시로 통일 ( 0 추가 )
- 접속시 초기시간 포멧 ( 23시 ~ 01시 ) 로 그대로 검색해도 검색 후 ( 23시 ~ 01시 ) 로 유지
  - 23 ~ 25 시 포멧 미채택 이유
    - TimePicker 로 선택 시 23시 ~ 27시 보이는 것보단
      -  23시 ~ 04시 가 더 좋아보여서 적용
