### PR TITLE
[#148]; feat: 지도 검색 버퍼 영역 추가 및 재검색 시 지도 초기화 버그 수정

### DIFF
--- a/pick-habju/src/components/Map/NaverMap.tsx
+++ b/pick-habju/src/components/Map/NaverMap.tsx
@@ -145,7 +145,10 @@ const NaverMap = forwardRef<NaverMapHandle, NaverMapProps>(
     }, [onMarkerClick]);
 
     // 네이버 지도 SDK 스크립트 로드 → 지도 인스턴스 생성 → 이벤트 리스너 등록.
-    // initialCenter·initialZoom이 바뀌면 지도를 재생성한다.
+    // initialCenter·initialZoom은 마운트 시 1회만 사용. props 변경 시 지도를 재생성하지 않는다.
+    const initialCenterRef = useRef(initialCenter);
+    const initialZoomRef = useRef(initialZoom);
+
     useEffect(() => {
       if (!mapContainerRef.current) return;
       // cleanup에서 ref.current를 직접 읽으면 lint 경고가 발생하므로 로컬에 캡처.
@@ -160,8 +163,8 @@ const NaverMap = forwardRef<NaverMapHandle, NaverMapProps>(
           setScriptError(null);
 
           const map = new naver.maps.Map(mapContainerRef.current, {
-            center: new naver.maps.LatLng(initialCenter.lat, initialCenter.lng),
-            zoom: initialZoom,
+            center: new naver.maps.LatLng(initialCenterRef.current.lat, initialCenterRef.current.lng),
+            zoom: initialZoomRef.current,
             zoomControl: false,
             mapDataControl: false,
           });
@@ -231,7 +234,7 @@ const NaverMap = forwardRef<NaverMapHandle, NaverMapProps>(
         }
         setReactPopover(null);
       };
-    }, [initialCenter.lat, initialCenter.lng, initialZoom]);
+    }, []);
 
     // markerViewModels 변경 시 마커 전체 재생성.
     // 단일 룸 마커: 클릭 시 바로 룸 선택.

--- a/pick-habju/src/constants/serviceable_stations.ts
+++ b/pick-habju/src/constants/serviceable_stations.ts
@@ -19,28 +19,28 @@ const SERVICEABLE_STATIONS: ServiceableStation[] = [
     name: '이수',
     subwayLine: '4호선·7호선',
     center: { lat: 37.485196, lng: 126.981605 },
-    bounds: { swLat: 37.465196, swLng: 126.956605, neLat: 37.505196, neLng: 127.006605 },
+    bounds: { swLat: 37.480196, swLng: 126.975605, neLat: 37.490196, neLng: 126.987605 },
   },
   {
     id: 'sadang',
     name: '사당',
     subwayLine: '2호선·4호선',
     center: { lat: 37.476550, lng: 126.981688 },
-    bounds: { swLat: 37.456550, swLng: 126.956688, neLat: 37.496550, neLng: 127.006688 },
+    bounds: { swLat: 37.471550, swLng: 126.975688, neLat: 37.481550, neLng: 126.987688 },
   },
   {
     id: 'hongdae',
     name: '홍대입구',
     subwayLine: '2호선·공항철도·경의중앙선',
     center: { lat: 37.556748, lng: 126.923643 },
-    bounds: { swLat: 37.536748, swLng: 126.898643, neLat: 37.576748, neLng: 126.948643 },
+    bounds: { swLat: 37.551748, swLng: 126.917643, neLat: 37.561748, neLng: 126.929643 },
   },
   {
     id: 'sinchon',
     name: '신촌',
     subwayLine: '2호선',
     center: { lat: 37.555153, lng: 126.936890 },
-    bounds: { swLat: 37.535153, swLng: 126.911890, neLat: 37.575153, neLng: 126.961890 },
+    bounds: { swLat: 37.550153, swLng: 126.930890, neLat: 37.560153, neLng: 126.942890 },
   },
 ];
 

--- a/pick-habju/src/constants/serviceable_stations.ts
+++ b/pick-habju/src/constants/serviceable_stations.ts
@@ -19,28 +19,28 @@ const SERVICEABLE_STATIONS: ServiceableStation[] = [
     name: '이수',
     subwayLine: '4호선·7호선',
     center: { lat: 37.485196, lng: 126.981605 },
-    bounds: { swLat: 37.4845, swLng: 126.9798, neLat: 37.4885, neLng: 126.9838 },
+    bounds: { swLat: 37.465196, swLng: 126.956605, neLat: 37.505196, neLng: 127.006605 },
   },
   {
     id: 'sadang',
     name: '사당',
     subwayLine: '2호선·4호선',
     center: { lat: 37.476550, lng: 126.981688 },
-    bounds: { swLat: 37.470000, swLng: 126.974000, neLat: 37.483000, neLng: 126.989000 },
+    bounds: { swLat: 37.456550, swLng: 126.956688, neLat: 37.496550, neLng: 127.006688 },
   },
   {
     id: 'hongdae',
     name: '홍대입구',
     subwayLine: '2호선·공항철도·경의중앙선',
     center: { lat: 37.556748, lng: 126.923643 },
-    bounds: { swLat: 37.554748, swLng: 126.921643, neLat: 37.558748, neLng: 126.925643 },
+    bounds: { swLat: 37.536748, swLng: 126.898643, neLat: 37.576748, neLng: 126.948643 },
   },
   {
     id: 'sinchon',
     name: '신촌',
     subwayLine: '2호선',
     center: { lat: 37.555153, lng: 126.936890 },
-    bounds: { swLat: 37.553153, swLng: 126.934890, neLat: 37.557153, neLng: 126.938890 },
+    bounds: { swLat: 37.535153, swLng: 126.911890, neLat: 37.575153, neLng: 126.961890 },
   },
 ];
 

--- a/pick-habju/src/pages/HomePage.tsx
+++ b/pick-habju/src/pages/HomePage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { expandBounds } from '../utils/mapQuery';
 import { useNavigate } from 'react-router-dom';
 
 // Components
@@ -40,7 +41,7 @@ const HomePage = () => {
 
   // 5. Event Handler: 검색 시작 (HeroArea에서 이미 full SearchParams 전달)
   const onSearch = (params: SearchParams) => {
-    setLastQuery(params);
+    setLastQuery({ ...params, bounds: expandBounds(params.bounds) });
     navigate(RoutePaths.MAP);
   };
 

--- a/pick-habju/src/pages/MapPage.tsx
+++ b/pick-habju/src/pages/MapPage.tsx
@@ -13,7 +13,7 @@ import type { NaverMapHandle } from '../types/map';
 import { formatSearchConditionDateTime } from '../utils/dateTimeLabel';
 import { buildMarkerViewModels } from '../utils/mapMarkerViewModel';
 
-const DEFAULT_MAP_ZOOM = 14;
+const DEFAULT_MAP_ZOOM = 16;
 
 /**
  * 지도 기반 합주실 검색 페이지.

--- a/pick-habju/src/utils/mapQuery.ts
+++ b/pick-habju/src/utils/mapQuery.ts
@@ -11,6 +11,21 @@ import type { MapBounds, MapViewport } from '../types/map';
 
 const BOUNDS_EPSILON = 0.000001;
 
+/**
+ * 뷰포트 span의 30%를 버퍼로 계산 (하한 0.002° ≈ 200m, 상한 0.025° ≈ 2.5km).
+ * 버퍼를 적용한 MapBounds 반환. API 호출 영역 및 lastQuery.bounds 저장에 사용.
+ */
+export const expandBounds = (bounds: MapBounds): MapBounds => {
+  const latBuffer = Math.min(Math.max((bounds.neLat - bounds.swLat) * 0.3, 0.002), 0.025);
+  const lngBuffer = Math.min(Math.max((bounds.neLng - bounds.swLng) * 0.3, 0.002), 0.025);
+  return {
+    swLat: bounds.swLat - latBuffer,
+    swLng: bounds.swLng - lngBuffer,
+    neLat: bounds.neLat + latBuffer,
+    neLng: bounds.neLng + lngBuffer,
+  };
+};
+
 const addOneHour = (time: string): string => {
   const parts = time.split(':');
   if (parts.length !== 2) {
@@ -31,14 +46,14 @@ const addOneHour = (time: string): string => {
   return `${String(nextHour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
 };
 
-/** 기존 검색 조건(date, peopleCount, hour_slots 등) 유지하고 center/bounds만 viewport 값으로 교체 */
+/** 기존 검색 조건(date, peopleCount, hour_slots 등) 유지하고 center는 viewport, bounds는 버퍼 적용한 값으로 교체 */
 export const mergeViewportToLastQuery = (
   lastQuery: SearchParams,
   viewport: MapViewport
 ): SearchParams => ({
   ...lastQuery,
   center: viewport.center,
-  bounds: viewport.bounds,
+  bounds: expandBounds(viewport.bounds),
 });
 
 /** 현재 bounds가 기준(base) bounds를 벗어났는지 판정 (약간의 오차 허용) */


### PR DESCRIPTION
<!-- 이슈번호를 작성해주세요 -->
Closes #148 

## 구현내용
### 버퍼 영역 추가
- expandBounds(bounds) 추가 — 뷰포트 span의 30% 버퍼 계산 (하한 200m, 상한 2.5km)
- "여기서 검색" 시 API 호출 영역 = 뷰포트 + 버퍼, "여기서 검색" 버튼 노출 기준도 동일
- 홈 → 지도 초기 진입도 동일하게 버퍼 적용 (onSearch에서 expandBounds 호출)
- 역 bounds를 zoom 16 뷰포트 기준으로 통일
- 초기 zoom 16으로 변경

## 특이사항
- 재검색 시 지도가 zoom 리셋되는 버그 수정 : initialCenter / initialZoom을 ref로 캡처해 마운트 시 1회만 사용하도록 수정. useEffect deps를 []로 변경.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Map & Search Improvements

* Default map zoom level increased for better initial visibility and detailed view of service areas when opening the app
* Service coverage areas updated across multiple serviceable stations to reflect current and accurate geographic boundaries
* Search functionality enhanced with improved boundary expansion calculations, providing more accurate and comprehensive results when users explore the map

<!-- end of auto-generated comment: release notes by coderabbit.ai -->