### PR TITLE
Feat/150 loading errornotice

### DIFF
--- a/pick-habju/src/api/api.types.ts
+++ b/pick-habju/src/api/api.types.ts
@@ -40,7 +40,8 @@ export interface Branch {
   branch: string;
   lat: number;
   lng: number;
-  min_price: number;
+  min_price_available: number;
+  min_price_partial: number;
   available_count: number;
   phone_number: string | null;
   display_name: string | null;

--- a/pick-habju/src/components/ErrorNotice/ErrorNotice.tsx
+++ b/pick-habju/src/components/ErrorNotice/ErrorNotice.tsx
@@ -9,14 +9,14 @@ import NoLocationIcon from '../../assets/svg/NoLocation.svg';
 const ErrorNotice = ({
   type,
   onClose,
-  autoHideAfter = 6000,
+  autoHideAfter,
   onAutoHide,
 }: ErrorNoticeProps) => {
   const [isVisible, setIsVisible] = useState(true);
 
-  // noMatch 타입일 때 자동 숨김 타이머
+  // noMatch 타입이고 autoHideAfter가 지정된 경우에만 자동 숨김 타이머 실행
   useEffect(() => {
-    if (type === 'noMatch' && isVisible) {
+    if (type === 'noMatch' && isVisible && autoHideAfter != null) {
       const timer = setTimeout(() => {
         setIsVisible(false);
         onAutoHide?.();

--- a/pick-habju/src/components/ErrorNotice/ErrorNotice.tsx
+++ b/pick-habju/src/components/ErrorNotice/ErrorNotice.tsx
@@ -78,7 +78,7 @@ const ErrorNotice = ({
   };
 
   return (
-    <div className="backdrop-blur-[3px] bg-[rgba(9,9,9,0.7)] flex flex-col items-center justify-center w-full h-full">
+    <div className="absolute inset-0 z-50 backdrop-blur-[3px] bg-[rgba(9,9,9,0.7)] flex flex-col items-center justify-center">
       <div className="flex flex-col items-center justify-center gap-4 flex-1 w-full">
         {/* 아이콘 */}
         <div className="shrink-0">{getIcon()}</div>

--- a/pick-habju/src/components/ErrorNotice/ErrorNotice.types.ts
+++ b/pick-habju/src/components/ErrorNotice/ErrorNotice.types.ts
@@ -5,7 +5,7 @@ export interface ErrorNoticeProps {
   type: NoticeType;
   /** 돌아가기 버튼 클릭 핸들러 (noResults 타입에서 사용) */
   onClose?: () => void;
-  /** 자동 숨김 시간 (ms) - noMatch 타입에서 기본 3000ms */
+  /** 자동 숨김 시간 (ms) - 지정하지 않으면 타이머 없이 배너 유지 */
   autoHideAfter?: number;
   /** 자동 숨김 시 콜백 함수. 부모 컴포넌트에서 필터 버튼 비활성화 (noMatch 타입에서 사용) */
   onAutoHide?: () => void;

--- a/pick-habju/src/components/FavoriteButton/FavoriteButton.tsx
+++ b/pick-habju/src/components/FavoriteButton/FavoriteButton.tsx
@@ -1,7 +1,7 @@
 import FaveOnIcon from '../../assets/svg/FaveOn.svg?react';
 import type { FavoriteButtonProps } from './FavoriteButton.types';
 
-const FavoriteButton = ({ isActive = false, onToggle }: FavoriteButtonProps) => {
+const FavoriteButton = ({ isActive = false, onToggle, disabled = false }: FavoriteButtonProps) => {
   const handleClick = () => {
     const nextValue = !isActive;
     onToggle?.(nextValue);
@@ -10,7 +10,8 @@ const FavoriteButton = ({ isActive = false, onToggle }: FavoriteButtonProps) => 
   return (
     <button
       type="button"
-      className={`h-10 rounded-[6.25rem] shadow-filter px-4 py-2.5 flex gap-1.25 items-center outline-none border border-transparent transition-colors ${
+      disabled={disabled}
+      className={`h-10 rounded-[6.25rem] shadow-filter px-4 py-2.5 flex gap-1.25 items-center outline-none border border-transparent transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
         isActive
           ? 'bg-yellow-700 text-primary-white [&_path]:fill-primary-white [&_path]:stroke-primary-white'
           : 'bg-primary-white text-gray-300 hover:bg-gray-200 [&_path]:fill-gray-300 [&_path]:stroke-gray-300'

--- a/pick-habju/src/components/FavoriteButton/FavoriteButton.tsx
+++ b/pick-habju/src/components/FavoriteButton/FavoriteButton.tsx
@@ -11,7 +11,7 @@ const FavoriteButton = ({ isActive = false, onToggle, disabled = false }: Favori
     <button
       type="button"
       disabled={disabled}
-      className={`h-10 rounded-[6.25rem] shadow-filter px-4 py-2.5 flex gap-1.25 items-center outline-none border border-transparent transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+      className={`h-10 rounded-[6.25rem] shadow-filter px-4 py-2.5 flex gap-1.25 items-center outline-none border border-transparent transition-colors disabled:cursor-not-allowed ${
         isActive
           ? 'bg-yellow-700 text-primary-white [&_path]:fill-primary-white [&_path]:stroke-primary-white'
           : 'bg-primary-white text-gray-300 hover:bg-gray-200 [&_path]:fill-gray-300 [&_path]:stroke-gray-300'

--- a/pick-habju/src/components/FavoriteButton/FavoriteButton.types.ts
+++ b/pick-habju/src/components/FavoriteButton/FavoriteButton.types.ts
@@ -1,4 +1,5 @@
 export interface FavoriteButtonProps {
   isActive?: boolean;
   onToggle?: (nextValue: boolean) => void;
+  disabled?: boolean;
 }

--- a/pick-habju/src/components/FilterSection/FilterSection.tsx
+++ b/pick-habju/src/components/FilterSection/FilterSection.tsx
@@ -12,12 +12,15 @@ const FilterSection = ({
   onPartialFilterToggle,
   onFavoriteFilterToggle,
   isFavoriteFilterActive = false,
+  partialDisabled = false,
+  favoriteDisabled = false,
 }: FilterSectionProps) => {
   return (
     <div className="flex items-center gap-2.5 w-91.5 h-12">
       <button
         type="button"
-        className={`h-10 rounded-[6.25rem] shadow-filter px-4 py-2.5 flex gap-1.25 items-center outline-none border border-transparent transition-colors ${
+        disabled={partialDisabled}
+        className={`h-10 rounded-[6.25rem] shadow-filter px-4 py-2.5 flex gap-1.25 items-center outline-none border border-transparent transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
           isPartialFilterActive
             ? 'bg-gray-600 text-primary-white [&_path]:fill-primary-white'
             : 'bg-primary-white text-gray-300 hover:bg-gray-200 [&_path]:fill-gray-300'
@@ -30,6 +33,7 @@ const FilterSection = ({
       <FavoriteButton
         isActive={isFavoriteFilterActive}
         onToggle={onFavoriteFilterToggle}
+        disabled={favoriteDisabled}
       />
     </div>
   );

--- a/pick-habju/src/components/FilterSection/FilterSection.tsx
+++ b/pick-habju/src/components/FilterSection/FilterSection.tsx
@@ -20,7 +20,7 @@ const FilterSection = ({
       <button
         type="button"
         disabled={partialDisabled}
-        className={`h-10 rounded-[6.25rem] shadow-filter px-4 py-2.5 flex gap-1.25 items-center outline-none border border-transparent transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+        className={`h-10 rounded-[6.25rem] shadow-filter px-4 py-2.5 flex gap-1.25 items-center outline-none border border-transparent transition-colors disabled:cursor-not-allowed ${
           isPartialFilterActive
             ? 'bg-gray-600 text-primary-white [&_path]:fill-primary-white'
             : 'bg-primary-white text-gray-300 hover:bg-gray-200 [&_path]:fill-gray-300'

--- a/pick-habju/src/components/FilterSection/FilterSection.types.ts
+++ b/pick-habju/src/components/FilterSection/FilterSection.types.ts
@@ -11,4 +11,8 @@ export interface FilterSectionProps {
   onFavoriteFilterToggle?: (isActive: boolean) => void;
   /** '찜한 합주실만 보기' 필터 활성 여부 */
   isFavoriteFilterActive?: boolean;
+  /** partial 필터 버튼 비활성화 여부 */
+  partialDisabled?: boolean;
+  /** favorite 필터 버튼 비활성화 여부 */
+  favoriteDisabled?: boolean;
 }

--- a/pick-habju/src/components/Map/MapLoadingSkeleton/MapLoadingSkeleton.tsx
+++ b/pick-habju/src/components/Map/MapLoadingSkeleton/MapLoadingSkeleton.tsx
@@ -53,7 +53,7 @@ const MapLoadingSkeleton = () => {
 
           {/* 도움말 메시지 */}
           <div className="flex flex-wrap items-center justify-center px-2.5 py-[5px] w-full">
-            <p className="font-modal-default text-primary-black text-center whitespace-pre-wrap">
+            <p className="font-modal-default text-primary-black text-center whitespace-nowrap">
               {tipMessage}
             </p>
           </div>

--- a/pick-habju/src/components/Map/MapLoadingSkeleton/MapLoadingSkeleton.tsx
+++ b/pick-habju/src/components/Map/MapLoadingSkeleton/MapLoadingSkeleton.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import noteIcon from '../../assets/svg/noteIcon.svg';
+import noteIcon from '../../../assets/svg/noteIcon.svg';
 
 const TIP_MESSAGES = [
   '딱 맞는 시간이 없다면 일부만 예약하는 방법도 있어요',

--- a/pick-habju/src/components/SearchBar/SearchBar.tsx
+++ b/pick-habju/src/components/SearchBar/SearchBar.tsx
@@ -6,11 +6,12 @@ import PersonIcon from '../../assets/svg/person.svg';
 import type { SearchBarProps } from './SearchBar.types';
 import { useDebounce } from '../../hook/useDebounce';
 
-const SearchBar = ({ 
-  value, 
-  onSearchChange, 
+const SearchBar = ({
+  value,
+  onSearchChange,
   searchCondition,
-  onConditionClick
+  onConditionClick,
+  disabled = false,
 }: SearchBarProps) => {
   const [searchText, setSearchText] = useState(value);
 
@@ -47,7 +48,8 @@ const SearchBar = ({
           placeholder="결과 내 합주실 검색"
           value={searchText}
           onChange={(e) => setSearchText(e.target.value)}
-          className="flex-1 min-w-0 outline-none text-gray-600 placeholder:text-gray-300 font-modal-call"
+          disabled={disabled}
+          className="flex-1 min-w-0 outline-none text-gray-600 placeholder:text-gray-300 font-modal-call disabled:cursor-not-allowed disabled:opacity-50"
         />
         <div className="shrink-0 w-12 h-12 flex items-center justify-center">
           {searchText.trim() && (

--- a/pick-habju/src/components/SearchBar/SearchBar.tsx
+++ b/pick-habju/src/components/SearchBar/SearchBar.tsx
@@ -49,7 +49,7 @@ const SearchBar = ({
           value={searchText}
           onChange={(e) => setSearchText(e.target.value)}
           disabled={disabled}
-          className="flex-1 min-w-0 outline-none text-gray-600 placeholder:text-gray-300 font-modal-call disabled:cursor-not-allowed disabled:opacity-50"
+          className="flex-1 min-w-0 outline-none text-gray-600 placeholder:text-gray-300 font-modal-call disabled:cursor-not-allowed"
         />
         <div className="shrink-0 w-12 h-12 flex items-center justify-center">
           {searchText.trim() && (

--- a/pick-habju/src/components/SearchBar/SearchBar.tsx
+++ b/pick-habju/src/components/SearchBar/SearchBar.tsx
@@ -52,10 +52,10 @@ const SearchBar = ({
           className="flex-1 min-w-0 outline-none text-gray-600 placeholder:text-gray-300 font-modal-call disabled:cursor-not-allowed"
         />
         <div className="shrink-0 w-12 h-12 flex items-center justify-center">
-          {searchText.trim() && (
-            <SearchCloseIcon 
-              className="w-4 h-4 cursor-pointer text-gray-300" 
-              onClick={handleClearText} 
+          {searchText.trim() && !disabled && (
+            <SearchCloseIcon
+              className="w-4 h-4 cursor-pointer text-gray-300"
+              onClick={handleClearText}
             />
           )}
         </div>

--- a/pick-habju/src/components/SearchBar/SearchBar.types.ts
+++ b/pick-habju/src/components/SearchBar/SearchBar.types.ts
@@ -11,4 +11,7 @@ export interface SearchBarProps {
   
   // 검색 조건 클릭 시 첫 화면으로 돌아가는 핸들러
   onConditionClick: () => void;
+
+  /** 검색 입력 비활성화 여부 (noMatch 화면 표시 중 필터가 원인일 때 상호작용 차단) */
+  disabled?: boolean;
 }

--- a/pick-habju/src/pages/MapPage.tsx
+++ b/pick-habju/src/pages/MapPage.tsx
@@ -91,7 +91,7 @@ const MapPage = () => {
   /** 필터·검색 변경 핸들러 — lastChangedFilter 갱신 포함 */
   const handlePartialFilterToggle  = useCallback((isActive: boolean) => { setIsPartialFilterActive(isActive);  setLastChangedFilter('partial');  }, []);
   const handleFavoriteFilterToggle = useCallback((isActive: boolean) => { setIsFavoriteFilterActive(isActive); setLastChangedFilter('favorite'); }, []);
-  const handleSearchChange         = useCallback((text: string)       => { setSearchText(text);                setLastChangedFilter('search');   }, []);
+  const handleSearchChange         = useCallback((text: string)       => { setSearchText(text); if (text) setLastChangedFilter('search'); }, []);
 
   /**
    * 선택된 룸이 속한 마커 ID → NaverMap에서 해당 마커 아이콘을 active 상태로 표시.

--- a/pick-habju/src/pages/MapPage.tsx
+++ b/pick-habju/src/pages/MapPage.tsx
@@ -81,30 +81,8 @@ const MapPage = () => {
     (markerViewModels.length === 0 ||
       (isFavoriteFilterActive && markerViewModels.every((m) => m.favorite === 'off')));
 
-  /**
-   * noMatch의 실질적 원인 필터.
-   * lastChangedFilter가 여전히 유효한 원인이면 그것을 사용하고,
-   * 아니면 현재 활성 상태를 기반으로 fallback 원인을 반환.
-   */
-  const noMatchCause = useMemo(() => {
-    if (!hasNoMatch) return null;
-    const isEmptyMarkers = markerViewModels.length === 0;
-    if (
-      (lastChangedFilter === 'partial'  && isPartialFilterActive  && isEmptyMarkers) ||
-      (lastChangedFilter === 'favorite' && isFavoriteFilterActive && !isEmptyMarkers && markerViewModels.every((m) => m.favorite === 'off')) ||
-      (lastChangedFilter === 'search'   && !!searchText           && isEmptyMarkers)
-    ) {
-      return lastChangedFilter;
-    }
-    // fallback: 현재 활성화된 원인 중 하나를 반환
-    if (isEmptyMarkers) {
-      if (isPartialFilterActive) return 'partial';
-      if (searchText)            return 'search';
-    } else if (isFavoriteFilterActive) {
-      return 'favorite';
-    }
-    return null;
-  }, [hasNoMatch, lastChangedFilter, isPartialFilterActive, isFavoriteFilterActive, searchText, markerViewModels]);
+  /** noMatch 원인 필터. noMatch 중 다른 필터는 disabled되므로 lastChangedFilter가 항상 원인. */
+  const noMatchCause = hasNoMatch ? lastChangedFilter : null;
 
   /** noMatch ErrorNotice 자동 숨김 시: 원인 필터 해제. 검색어는 자동 초기화 안 함(사용자가 직접 지워야 함). */
   const handleNoMatchAutoHide = useCallback(() => {
@@ -336,7 +314,13 @@ const MapPage = () => {
             isCarouselOpen ? 'bottom-74' : 'bottom-6'
           }`}
         >
-          <SearchHereButton onClick={() => handleSearchHere(resetSelectionUiState)} />
+          <SearchHereButton onClick={() => handleSearchHere(() => {
+            resetSelectionUiState();
+            setIsPartialFilterActive(false);
+            setIsFavoriteFilterActive(false);
+            setSearchText('');
+            setLastChangedFilter(null);
+          })} />
         </div>
       )}
     </div>

--- a/pick-habju/src/pages/MapPage.tsx
+++ b/pick-habju/src/pages/MapPage.tsx
@@ -2,7 +2,9 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import CardCarousel from '../components/CardCarousel/CardCarousel';
 import type { CardCarouselRoom } from '../components/CardCarousel/CardCarousel.types';
+import ErrorNotice from '../components/ErrorNotice/ErrorNotice';
 import FilterSection from '../components/FilterSection/FilterSection';
+import MapLoadingSkeleton from '../components/Map/MapLoadingSkeleton/MapLoadingSkeleton';
 import NaverMap from '../components/Map/NaverMap';
 import SearchBar from '../components/SearchBar/SearchBar';
 import SearchHereButton from '../components/SearchHereButton/SearchHereButton';
@@ -38,11 +40,16 @@ const MapPage = () => {
   // ── 검색 텍스트 (브랜치명 필터) ──
   const [searchText, setSearchText] = useState('');
 
+  // ── noMatch 원인 추적 ──
+  /** 사용자가 마지막으로 변경한 필터·검색. noMatch 발생 시 원인 판별에 사용. */
+  const [lastChangedFilter, setLastChangedFilter] = useState<'partial' | 'favorite' | 'search' | null>(null);
+
   // ── 검색 결과 (hook) ──
   const {
     showSearchHereButton,
     handleViewportChange,
     handleSearchHere,
+    isLoading,
     roomsById,
     results,
     branchSummary,
@@ -62,6 +69,53 @@ const MapPage = () => {
       }),
     [branchSummary, favoriteBizItemIds, isPartialFilterActive, isFavoriteFilterActive, results, searchText]
   );
+
+  /** API 결과 자체가 없음 (로딩 완료 후 results 빈 배열) */
+  const hasNoResults = !isLoading && results.length === 0;
+  /** 필터·검색으로 표시할 마커가 없음.
+   * - partial 필터 / 검색텍스트 → markerViewModels 자체가 비어 있음
+   * - 즐겨찾기 필터 → markerViewModels는 있지만 favorite 'on'인 마커가 하나도 없음 */
+  const hasNoMatch =
+    !isLoading &&
+    results.length > 0 &&
+    (markerViewModels.length === 0 ||
+      (isFavoriteFilterActive && markerViewModels.every((m) => m.favorite === 'off')));
+
+  /**
+   * noMatch의 실질적 원인 필터.
+   * lastChangedFilter가 여전히 유효한 원인이면 그것을 사용하고,
+   * 아니면 현재 활성 상태를 기반으로 fallback 원인을 반환.
+   */
+  const noMatchCause = useMemo(() => {
+    if (!hasNoMatch) return null;
+    const isEmptyMarkers = markerViewModels.length === 0;
+    if (
+      (lastChangedFilter === 'partial'  && isPartialFilterActive  && isEmptyMarkers) ||
+      (lastChangedFilter === 'favorite' && isFavoriteFilterActive && !isEmptyMarkers && markerViewModels.every((m) => m.favorite === 'off')) ||
+      (lastChangedFilter === 'search'   && !!searchText           && isEmptyMarkers)
+    ) {
+      return lastChangedFilter;
+    }
+    // fallback: 현재 활성화된 원인 중 하나를 반환
+    if (isEmptyMarkers) {
+      if (isPartialFilterActive) return 'partial';
+      if (searchText)            return 'search';
+    } else if (isFavoriteFilterActive) {
+      return 'favorite';
+    }
+    return null;
+  }, [hasNoMatch, lastChangedFilter, isPartialFilterActive, isFavoriteFilterActive, searchText, markerViewModels]);
+
+  /** noMatch ErrorNotice 자동 숨김 시: 원인 필터 해제. 검색어는 자동 초기화 안 함(사용자가 직접 지워야 함). */
+  const handleNoMatchAutoHide = useCallback(() => {
+    if (noMatchCause === 'partial')  setIsPartialFilterActive(false);
+    if (noMatchCause === 'favorite') setIsFavoriteFilterActive(false);
+  }, [noMatchCause]);
+
+  /** 필터·검색 변경 핸들러 — lastChangedFilter 갱신 포함 */
+  const handlePartialFilterToggle  = useCallback((isActive: boolean) => { setIsPartialFilterActive(isActive);  setLastChangedFilter('partial');  }, []);
+  const handleFavoriteFilterToggle = useCallback((isActive: boolean) => { setIsFavoriteFilterActive(isActive); setLastChangedFilter('favorite'); }, []);
+  const handleSearchChange         = useCallback((text: string)       => { setSearchText(text);                setLastChangedFilter('search');   }, []);
 
   /**
    * 선택된 룸이 속한 마커 ID → NaverMap에서 해당 마커 아이콘을 active 상태로 표시.
@@ -223,6 +277,17 @@ const MapPage = () => {
 
   return (
     <div className="relative h-full w-full">
+      {isLoading && <MapLoadingSkeleton />}
+      {hasNoResults && (
+        <ErrorNotice type="noResults" onClose={() => navigate(-1)} />
+      )}
+      {hasNoMatch && (
+        <ErrorNotice
+          type="noMatch"
+          autoHideAfter={noMatchCause !== 'search' ? 6000 : undefined}
+          onAutoHide={noMatchCause !== 'search' ? handleNoMatchAutoHide : undefined}
+        />
+      )}
       <NaverMap
         ref={mapRef}
         initialCenter={lastQuery.center}
@@ -242,15 +307,18 @@ const MapPage = () => {
       <div className="absolute left-0 right-0 top-0 z-10 flex flex-col gap-3 p-3">
         <SearchBar
           value={searchText}
-          onSearchChange={setSearchText}
+          onSearchChange={handleSearchChange}
           searchCondition={searchCondition}
           onConditionClick={() => navigate(RoutePaths.HOME)}
+          disabled={hasNoMatch && noMatchCause !== 'search'}
         />
         <FilterSection
           isPartialFilterActive={isPartialFilterActive}
-          onPartialFilterToggle={setIsPartialFilterActive}
+          onPartialFilterToggle={handlePartialFilterToggle}
           isFavoriteFilterActive={isFavoriteFilterActive}
-          onFavoriteFilterToggle={setIsFavoriteFilterActive}
+          onFavoriteFilterToggle={handleFavoriteFilterToggle}
+          partialDisabled={hasNoMatch && noMatchCause !== 'partial'}
+          favoriteDisabled={hasNoMatch && noMatchCause !== 'favorite'}
         />
       </div>
 

--- a/pick-habju/src/pages/MapPage.tsx
+++ b/pick-habju/src/pages/MapPage.tsx
@@ -206,6 +206,17 @@ const MapPage = () => {
     setOpenedMarkerPopoverId(null);
   }, []);
 
+  /** "여기서 검색" 클릭 시: 선택 UI·필터·검색어를 초기화한 뒤 재검색. */
+  const handleSearchHereClick = useCallback(() => {
+    handleSearchHere(() => {
+      resetSelectionUiState();
+      setIsPartialFilterActive(false);
+      setIsFavoriteFilterActive(false);
+      setSearchText('');
+      setLastChangedFilter(null);
+    });
+  }, [handleSearchHere, resetSelectionUiState]);
+
   // 필터·검색 텍스트 변경 시 선택 UI 초기화.
   useEffect(() => {
     resetSelectionUiState();
@@ -312,13 +323,7 @@ const MapPage = () => {
             isCarouselOpen ? 'bottom-74' : 'bottom-6'
           }`}
         >
-          <SearchHereButton onClick={() => handleSearchHere(() => {
-            resetSelectionUiState();
-            setIsPartialFilterActive(false);
-            setIsFavoriteFilterActive(false);
-            setSearchText('');
-            setLastChangedFilter(null);
-          })} />
+          <SearchHereButton onClick={handleSearchHereClick} />
         </div>
       )}
     </div>

--- a/pick-habju/src/pages/MapPage.tsx
+++ b/pick-habju/src/pages/MapPage.tsx
@@ -68,14 +68,14 @@ const MapPage = () => {
     [branches, favoriteBizItemIds, isPartialFilterActive, isFavoriteFilterActive, searchText]
   );
 
-  /** API 결과 자체가 없음 (로딩 완료 후 results 빈 배열) */
-  const hasNoResults = !isLoading && results.length === 0;
+  /** API 결과 자체가 없음 (로딩 완료 후 branches 빈 배열) */
+  const hasNoResults = !isLoading && branches.length === 0;
   /** 필터·검색으로 표시할 마커가 없음.
    * - partial 필터 / 검색텍스트 → markerViewModels 자체가 비어 있음
    * - 즐겨찾기 필터 → markerViewModels는 있지만 favorite 'on'인 마커가 하나도 없음 */
   const hasNoMatch =
     !isLoading &&
-    results.length > 0 &&
+    branches.length > 0 &&
     (markerViewModels.length === 0 ||
       (isFavoriteFilterActive && markerViewModels.every((m) => m.favorite === 'off')));
 

--- a/pick-habju/src/pages/MapPage.tsx
+++ b/pick-habju/src/pages/MapPage.tsx
@@ -68,14 +68,18 @@ const MapPage = () => {
     [branches, favoriteBizItemIds, isPartialFilterActive, isFavoriteFilterActive, searchText]
   );
 
-  /** API 결과 자체가 없음 (로딩 완료 후 branches 빈 배열) */
-  const hasNoResults = !isLoading && branches.length === 0;
-  /** 필터·검색으로 표시할 마커가 없음.
+  /** API 결과가 없거나, 필터 없이도 표시할 방이 없음 (모든 방이 일부 시간만 가능인 경우 포함) */
+  const hasNoResults =
+    !isLoading &&
+    (branches.length === 0 ||
+      (!isPartialFilterActive && !isFavoriteFilterActive && !searchText && markerViewModels.length === 0));
+  /** 필터·검색이 활성화된 상태에서 표시할 마커가 없음.
    * - partial 필터 / 검색텍스트 → markerViewModels 자체가 비어 있음
    * - 즐겨찾기 필터 → markerViewModels는 있지만 favorite 'on'인 마커가 하나도 없음 */
   const hasNoMatch =
     !isLoading &&
     branches.length > 0 &&
+    (isPartialFilterActive || isFavoriteFilterActive || !!searchText) &&
     (markerViewModels.length === 0 ||
       (isFavoriteFilterActive && markerViewModels.every((m) => m.favorite === 'off')));
 

--- a/pick-habju/src/pages/MapPage.tsx
+++ b/pick-habju/src/pages/MapPage.tsx
@@ -280,7 +280,7 @@ const MapPage = () => {
       />
 
       {/* 검색바 + 필터 — 지도 위 float 오버레이 */}
-      <div className="absolute left-0 right-0 top-0 z-10 flex flex-col gap-3 p-3">
+      <div className="absolute left-0 right-0 top-0 z-[60] flex flex-col gap-3 p-3">
         <SearchBar
           value={searchText}
           onSearchChange={handleSearchChange}

--- a/pick-habju/src/pages/MapPage.tsx
+++ b/pick-habju/src/pages/MapPage.tsx
@@ -224,11 +224,7 @@ const MapPage = () => {
   // 필터·검색 텍스트 변경 시 선택 UI 초기화.
   useEffect(() => {
     resetSelectionUiState();
-  }, [isFavoriteFilterActive, isPartialFilterActive, resetSelectionUiState]);
-
-  useEffect(() => {
-    resetSelectionUiState();
-  }, [searchText, resetSelectionUiState]);
+  }, [isFavoriteFilterActive, isPartialFilterActive, searchText, resetSelectionUiState]);
 
   // lastQuery 없으면 홈으로 redirect (직접 URL 접근 방지)
   useEffect(() => {

--- a/pick-habju/src/pages/MapPage.tsx
+++ b/pick-habju/src/pages/MapPage.tsx
@@ -319,7 +319,7 @@ const MapPage = () => {
       )}
       {showSearchHereButton && (
         <div
-          className={`absolute left-1/2 z-[60] -translate-x-1/2 transition-all duration-300 ease-out ${
+          className={`absolute left-1/2 z-40 -translate-x-1/2 transition-all duration-300 ease-out ${
             isCarouselOpen ? 'bottom-74' : 'bottom-6'
           }`}
         >

--- a/pick-habju/src/utils/mapMarkerViewModel.ts
+++ b/pick-habju/src/utils/mapMarkerViewModel.ts
@@ -81,7 +81,7 @@ export const buildMarkerViewModels = ({
       id: branch.business_id,
       lat: branch.lat,
       lng: branch.lng,
-      priceText: formatPriceText(branch.min_price),
+      priceText: formatPriceText(isPartialFilterActive ? branch.min_price_partial : branch.min_price_available),
       isPartial,
       favorite,
       isActive: false,


### PR DESCRIPTION
<!-- 이슈번호를 작성해주세요 -->
Closes #150 

## 특이사항
<!-- 구현 시 고려한 사항이나 주의점이 있다면 작성해주세요 -->
- 검색바에서 검색해서 noMatch 화면 나올 때는 6초 후 초기화가 아닌 사용자가 직접 지우는 방식
- 필터 있는 상태 (찜한 합주실 버튼, 일부시간만 가능 버튼, 검색어 입력) 에서 재검색을 하면 필터 초기화 됨. 
- noMatch 상태일 때는 원인 필터 외의 다른 필터 disabled 됨. 
- API 응답구조 min_price_available, min_price_partial 로 변경됨에 따른 코드 수정까지 했습니다.

## 구현 내용
### 필터 버튼 비활성화, 검색바 비활성화 : noMatch 중 원인 필터만 조작 가능, 나머지는 비활성 처리 / 필터가 noMatch 원인일 때 검색바 입력 비활성, 검색어가 원인일 때는 활성 유지  
- `FilterSection`의 `disabled`를 `partialDisabled` / `favoriteDisabled`로 분리  
- `FavoriteButton`에 `disabled` prop 추가
- `SearchBar`에 `disabled` prop 추가

### 로딩 화면
API 요청 중 `MapLoadingSkeleton` 표시

### 결과 없음 화면
API 결과가 빈 배열일 때 `ErrorNotice(type="noResults")` 표시
모든 방이 일부 시간만 가능인 경우도 noResults ErrorNotice 표시

### 필터 불일치 화면
필터·검색어 적용 후 표시할 마커가 없을 때 `ErrorNotice(type="noMatch")` 표시
- 원인 필터 판별: `lastChangedFilter` 상태로 사용자가 마지막으로 변경한 필터를 추적

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Search here" to refine map searches.
  * Map loading skeleton while data loads.

* **Changes**
  * "No results" and "No match" notices: auto-hide only when an explicit duration is provided.
  * Price display now reflects the active partial filter (shows partial vs available pricing).

* **UI / Accessibility**
  * Controls (search input, filter buttons, favorite button) can be disabled and show a disabled visual state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->