### PR TITLE
Fix/151 image modal fix

### DIFF
--- a/pick-habju/src/components/Modal/ImageCarouselModal.tsx
+++ b/pick-habju/src/components/Modal/ImageCarouselModal.tsx
@@ -3,6 +3,7 @@ import Chevron from '../../components/Chevron/Chevron';
 import { ChevronVariant } from '../../components/Chevron/ChevronEnums';
 import TurnOffIcon from '../../assets/svg/turnOff.svg';
 import ModalOverlay from './ModalOverlay';
+import { useIsWindows } from '../../hook/useIsWindow';
 
 type ImageCarouselModalProps = {
   images: string[];
@@ -11,6 +12,7 @@ type ImageCarouselModalProps = {
 };
 
 const ImageCarouselModal = ({ images, initialIndex = 0, onClose }: ImageCarouselModalProps) => {
+  const isWindows = useIsWindows();
   const [current, setCurrent] = useState(initialIndex);
 
   useEffect(() => {
@@ -26,9 +28,9 @@ const ImageCarouselModal = ({ images, initialIndex = 0, onClose }: ImageCarousel
 
   return (
     <ModalOverlay onClose={onClose} dimmedClassName="bg-black/80" blurClassName="" animateFromBottom={false}>
-      {/* 1. 최상위 컨테이너: 너비를 고정하고 내부 그림자를 위해 overflow-visible 상태 유지 */}
-      <div className="w-[min(25.125rem,calc(100vw-2rem))] relative">
-        {/* 2. 슬라이드 윈도우: 여기서만 옆 이미지를 잘라냄 */}
+      <div className={`w-full ${isWindows ? 'max-w-[26.875rem]' : 'max-w-[25.9375rem]'} relative`}>
+
+        {/* 슬라이드 윈도우 */}
         <div className="overflow-hidden w-full">
           <div
             className="flex items-center"
@@ -39,9 +41,7 @@ const ImageCarouselModal = ({ images, initialIndex = 0, onClose }: ImageCarousel
           >
             {images.map((image, index) => (
               <div key={index} className="w-full min-w-full flex-shrink-0 flex flex-col items-center">
-                {/* 3. 개별 이미지 컨테이너: 위쪽 여백 확보 */}
-                <div className="relative w-full mt-12 mb-4 px-3">
-                  {/* px-3은 그림자가 잘리는 것 방지용 */}
+                <div className="relative w-full mt-12 mb-4">
 
                   {/* 닫기 버튼 */}
                   <div className="absolute bottom-full right-0 z-10">
@@ -54,7 +54,7 @@ const ImageCarouselModal = ({ images, initialIndex = 0, onClose }: ImageCarousel
                     </button>
                   </div>
 
-                  {/* 이미지와 그림자 */}
+                  {/* 이미지 */}
                   <img
                     src={image}
                     alt={`확대 이미지 ${index + 1}`}
@@ -66,14 +66,15 @@ const ImageCarouselModal = ({ images, initialIndex = 0, onClose }: ImageCarousel
           </div>
         </div>
 
-        {/* 4. 컨트롤 오버레이 (Chevron) */}
-        <div className="pointer-events-none absolute top-12 left-3 right-3 bottom-0 flex items-center">
+        {/* 컨트롤 오버레이 (Chevron) */}
+        <div className="pointer-events-none absolute top-12 left-0 right-0 bottom-0 flex items-center">
           {total > 1 && (
             <div className="pointer-events-auto flex justify-between items-center w-full">
               <Chevron variant={variant} onPrev={prev} onNext={next} containerClassName="w-full" />
             </div>
           )}
         </div>
+
       </div>
     </ModalOverlay>
   );

--- a/pick-habju/src/components/Modal/ImageCarouselModal.tsx
+++ b/pick-habju/src/components/Modal/ImageCarouselModal.tsx
@@ -31,7 +31,7 @@ const ImageCarouselModal = ({
   return (
     <ModalOverlay onClose={onClose} dimmedClassName="bg-black/80" animateFromBottom={false} >
       {/* 1. 최상위 컨테이너: 너비를 고정하고 내부 그림자를 위해 overflow-visible 상태 유지 */}
-      <div className="w-[25.125rem] relative">
+      <div className="w-[calc(100vw-2rem)] max-w-[25.125rem] relative">
         
         {/* 2. 슬라이드 윈도우: 여기서만 옆 이미지를 잘라냄 */}
         <div className="overflow-hidden w-full">

--- a/pick-habju/src/components/Modal/ImageCarouselModal.tsx
+++ b/pick-habju/src/components/Modal/ImageCarouselModal.tsx
@@ -10,13 +10,9 @@ type ImageCarouselModalProps = {
   onClose: () => void;
 };
 
-const ImageCarouselModal = ({
-  images,
-  initialIndex = 0,
-  onClose,
-}: ImageCarouselModalProps) => {
+const ImageCarouselModal = ({ images, initialIndex = 0, onClose }: ImageCarouselModalProps) => {
   const [current, setCurrent] = useState(initialIndex);
-  
+
   useEffect(() => {
     setCurrent(initialIndex);
   }, [initialIndex]);
@@ -29,30 +25,24 @@ const ImageCarouselModal = ({
     current === 0 ? ChevronVariant.First : current === total - 1 ? ChevronVariant.Last : ChevronVariant.Middle;
 
   return (
-    <ModalOverlay onClose={onClose} dimmedClassName="bg-black/80" animateFromBottom={false} >
+    <ModalOverlay onClose={onClose} dimmedClassName="bg-black/80" blurClassName="" animateFromBottom={false}>
       {/* 1. 최상위 컨테이너: 너비를 고정하고 내부 그림자를 위해 overflow-visible 상태 유지 */}
-      <div className="w-[calc(100vw-2rem)] max-w-[25.125rem] relative">
-        
+      <div className="w-[min(25.125rem,calc(100vw-2rem))] relative">
         {/* 2. 슬라이드 윈도우: 여기서만 옆 이미지를 잘라냄 */}
         <div className="overflow-hidden w-full">
           <div
             className="flex items-center"
             style={{
-              // 이미지 너비(100%) + 간격(예: 40px) 만큼 이동하도록 설정
-              transform: `translateX(calc(-${current * 100}% - ${current * 40}px))`,
+              transform: `translateX(-${current * 100}%)`,
               transition: 'transform 0.35s ease-out',
-              gap: '40px', // 이미지 사이의 간격을 충분히 주어 옆 이미지가 안 보이게 함
             }}
           >
             {images.map((image, index) => (
-              <div 
-                key={index} 
-                className="w-full min-w-full flex-shrink-0 flex flex-col items-center"
-              >
+              <div key={index} className="w-full min-w-full flex-shrink-0 flex flex-col items-center">
                 {/* 3. 개별 이미지 컨테이너: 위쪽 여백 확보 */}
-                <div className="relative w-full mt-12 mb-4 px-3"> 
+                <div className="relative w-full mt-12 mb-4 px-3">
                   {/* px-3은 그림자가 잘리는 것 방지용 */}
-                  
+
                   {/* 닫기 버튼 */}
                   <div className="absolute bottom-full right-0 z-10">
                     <button

--- a/pick-habju/src/components/Modal/ModalOverlay.tsx
+++ b/pick-habju/src/components/Modal/ModalOverlay.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { motion } from 'framer-motion';
 
 type ModalOverlayProps = {
@@ -43,7 +44,7 @@ const ModalOverlay = ({
 
   if (!open) return null;
 
-  return (
+  return createPortal(
     <div
       ref={overlayRef}
       className={`fixed inset-0 z-50 flex items-center justify-center ${dimmedClassName} backdrop-blur-[2px]`}
@@ -63,7 +64,8 @@ const ModalOverlay = ({
       ) : (
         <div onClick={(e) => e.stopPropagation()}>{children}</div>
       )}
-    </div>
+    </div>,
+    document.body
   );
 };
 

--- a/pick-habju/src/components/Modal/ModalOverlay.tsx
+++ b/pick-habju/src/components/Modal/ModalOverlay.tsx
@@ -47,7 +47,7 @@ const ModalOverlay = ({
   return createPortal(
     <div
       ref={overlayRef}
-      className={`fixed inset-0 z-50 flex items-center justify-center ${dimmedClassName} backdrop-blur-[2px]`}
+      className={`fixed inset-0 z-[70] flex items-center justify-center ${dimmedClassName} backdrop-blur-[2px]`}
       onClick={(e) => {
         if (!lockBackground && e.target === overlayRef.current) onClose();
       }}

--- a/pick-habju/src/components/Modal/ModalOverlay.tsx
+++ b/pick-habju/src/components/Modal/ModalOverlay.tsx
@@ -8,6 +8,8 @@ type ModalOverlayProps = {
   children: React.ReactNode;
   /** 배경색 투명도 조절이 필요한 경우 (예: 이미지 캐러셀은 더 어둡게) */
   dimmedClassName?: string;
+  /** backdrop-blur 클래스 (기본 'backdrop-blur-[2px]', 빈 문자열로 비활성화 가능) */
+  blurClassName?: string;
   /** 클릭 시 닫힘 방지 옵션 (강제 선택이 필요한 경우 true) */
   lockBackground?: boolean;
   /** 아래→위 슬라이드 애니메이션 (false: ImageCarousel 등 즉시 표시) */
@@ -19,6 +21,7 @@ const ModalOverlay = ({
   onClose,
   children,
   dimmedClassName = 'bg-black/60',
+  blurClassName = 'backdrop-blur-[2px]',
   lockBackground = false,
   animateFromBottom = true,
 }: ModalOverlayProps) => {
@@ -47,7 +50,7 @@ const ModalOverlay = ({
   return createPortal(
     <div
       ref={overlayRef}
-      className={`fixed inset-0 z-[70] flex items-center justify-center ${dimmedClassName} backdrop-blur-[2px]`}
+      className={`fixed -inset-px z-[70] flex items-center justify-center overflow-hidden ${dimmedClassName} ${blurClassName}`}
       onClick={(e) => {
         if (!lockBackground && e.target === overlayRef.current) onClose();
       }}

--- a/pick-habju/src/layout/AppWrapper.tsx
+++ b/pick-habju/src/layout/AppWrapper.tsx
@@ -29,8 +29,8 @@ const AppWrapper = ({ children }: AppWrapperProps) => {
 
         {/* 스크롤 영역: 헤더 제외 나머지 */}
         <div
-          className={`flex-1 flex flex-col scrollbar-stable ${
-            isMapPage ? 'overflow-hidden' : 'overflow-y-auto overflow-x-hidden items-center'
+          className={`flex-1 flex flex-col ${
+            isMapPage ? 'overflow-hidden' : 'scrollbar-stable overflow-y-auto overflow-x-hidden items-center'
           }`}
         >
           <div className={`w-full flex flex-col items-center ${isMapPage ? 'h-full' : ''}`}>{children}</div>


### PR DESCRIPTION
<!-- 이슈번호를 작성해주세요 -->
Closes #151 

## 특이사항
<!-- 구현 시 고려한 사항이나 주의점이 있다면 작성해주세요 -->
이미지 크기가 뷰포트에 꽉 차게 해야 해서 useIsWindow 사용해서 window 일 때와 아닐 때 AppWrapper 의 뷰포트 너비에 정확히 맞출 수 있도록 했습니다.


## 구현 내용
### ImageCarouselModal 반응형
모달 너비를 고정값(25.125rem)에서 w-[min(25.125rem,calc(100vw-2rem))]으로 변경하여 작은 화면에서 모달이 잘리는 문제 수정

### ImageCarouselModal 슬라이드 로직 수정
기존 gap + calc 조합의 복잡한 offset 계산을 translateX(-${current * 100}%)로 단순화

### ModalOverlay z-index 수정

### AppWrapper scrollbar-stable 조건 수정
스크롤바가 존재하지 않는 맵 페이지에서 불필요하게 scrollbar-stable이 적용되던 문제 수정

### ModalOverlay에 createPortal 적용
ModalOverlay에 createPortal 적용해서 document.body에 직접 마운트하는 방식으로 수정 -> 모든 모달이 캐러셀 패널 기준이 아닌 화면 전체 기준으로 뜨도록 함.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Modal overlays now support a customizable blur setting and render via portal for more consistent stacking.

* **Improvements**
  * Modal width is now responsive and adapts to Windows vs other OS sizing for better fit.
  * Image carousel uses simplified slide behavior for smoother transitions and tighter layout.
  * Page scroll behavior adjusted to remove stable scrollbar on the map page for cleaner display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->