### PR TITLE
[#161]; fix: footer text 깨짐 및 width 최신화

### DIFF
--- a/pick-habju/src/components/Footer/Footer.tsx
+++ b/pick-habju/src/components/Footer/Footer.tsx
@@ -14,7 +14,9 @@ const Footer = () => {
         >
           공지사항
         </a>
-        <span className="whitespace-nowrap">|</span>
+        <span className="whitespace-nowrap" aria-hidden="true">
+          |
+        </span>
         <a
           href="https://forms.gle/uea6mtKQSBoAN7fs6"
           target="_blank"
@@ -24,7 +26,9 @@ const Footer = () => {
         >
           서비스 피드백하기
         </a>
-        <span className="whitespace-nowrap">|</span>
+        <span className="whitespace-nowrap" aria-hidden="true">
+          |
+        </span>
         <a
           href="mailto:pickhabju@gmail.com"
           className="cursor-pointer hover:underline hover:text-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-sm transition-colors whitespace-nowrap"

--- a/pick-habju/src/components/Footer/Footer.tsx
+++ b/pick-habju/src/components/Footer/Footer.tsx
@@ -1,7 +1,7 @@
 const Footer = () => {
   return (
     <div
-      className="flex w-full max-w-100.5 h-[9.3125rem] pt-[1.25rem] pr-[2.03125rem] pb-[3.6875rem] pl-[2.03125rem] flex-col items-center bg-[#FFFBF0]"
+      className="flex w-full max-w-[25.125rem] h-[9.3125rem] pt-[1.25rem] pr-[2.03125rem] pb-[3.6875rem] pl-[2.03125rem] flex-col items-center bg-[#FFFBF0]"
       aria-label="사이트 푸터"
     >
       <div className="flex items-center justify-center text-gray-400 font-footer-button py-4 px-1 gap-1">
@@ -27,7 +27,7 @@ const Footer = () => {
         <span className="whitespace-nowrap">|</span>
         <a
           href="mailto:pickhabju@gmail.com"
-          className="cursor-pointer hover:underline hover:text-blue-500 transition-colors whitespace-nowrap"
+          className="cursor-pointer hover:underline hover:text-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-sm transition-colors whitespace-nowrap"
           aria-label="이메일 보내기"
         >
           이메일 pickhabju@gmail.com

--- a/pick-habju/src/components/Footer/Footer.tsx
+++ b/pick-habju/src/components/Footer/Footer.tsx
@@ -1,44 +1,37 @@
 const Footer = () => {
   return (
     <div
-      className="flex w-full max-w-[25.9375rem] h-[9.3125rem] pt-[1.25rem] pr-[2.03125rem] pb-[3.6875rem] pl-[2.03125rem] flex-col items-center bg-[#FFFBF0]"
+      className="flex w-full max-w-100.5 h-[9.3125rem] pt-[1.25rem] pr-[2.03125rem] pb-[3.6875rem] pl-[2.03125rem] flex-col items-center bg-[#FFFBF0]"
       aria-label="사이트 푸터"
     >
-      <div className="flex items-center text-gray-400 font-footer-button py-4 px-1">
-        <span>
-          <a
-            href="https://twilight-utahraptor-df2.notion.site/24ab56bc00678022b173d901996f0b14"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="서비스 공지사항 (새 탭에서 열림)"
-            className="ml-1 cursor-pointer hover:underline hover:text-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-sm transition-colors"
-          >
-            {`공지사항 `}
-          </a>
-          |
-        </span>
-        <span>
-          <a
-            href="https://forms.gle/uea6mtKQSBoAN7fs6"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="서비스 피드백하기 (새 탭에서 열림)"
-            className="ml-1 cursor-pointer hover:underline hover:text-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-sm transition-colors"
-          >
-            {`서비스 피드백하기 `}
-          </a>
-          |
-        </span>
-        <span>
-          &nbsp;
-          <a
-            href="mailto:pickhabju@gmail.com"
-            className="cursor-pointer hover:underline hover:text-blue-500 transition-colors"
-            aria-label="이메일 보내기"
-          >
-            이메일 pickhabju@gmail.com
-          </a>
-        </span>
+      <div className="flex items-center justify-center text-gray-400 font-footer-button py-4 px-1 gap-1">
+        <a
+          href="https://twilight-utahraptor-df2.notion.site/24ab56bc00678022b173d901996f0b14"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="서비스 공지사항 (새 탭에서 열림)"
+          className="cursor-pointer hover:underline hover:text-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-sm transition-colors whitespace-nowrap"
+        >
+          공지사항
+        </a>
+        <span className="whitespace-nowrap">|</span>
+        <a
+          href="https://forms.gle/uea6mtKQSBoAN7fs6"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="서비스 피드백하기 (새 탭에서 열림)"
+          className="cursor-pointer hover:underline hover:text-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-sm transition-colors whitespace-nowrap"
+        >
+          서비스 피드백하기
+        </a>
+        <span className="whitespace-nowrap">|</span>
+        <a
+          href="mailto:pickhabju@gmail.com"
+          className="cursor-pointer hover:underline hover:text-blue-500 transition-colors whitespace-nowrap"
+          aria-label="이메일 보내기"
+        >
+          이메일 pickhabju@gmail.com
+        </a>
       </div>
 
       <div className="flex justify-center items-center gap-[0.625rem] px-[0.625rem] py-[0.25rem]">

--- a/pick-habju/src/components/Header/AppHeader.tsx
+++ b/pick-habju/src/components/Header/AppHeader.tsx
@@ -18,7 +18,7 @@ const AppHeader = () => {
   return (
     <div className="flex w-full justify-center items-center relative">
       <GoogleFormToast />
-      <div className="flex flex-col w-full max-w-[25.9375rem]">
+      <div className="flex flex-col w-full max-w-100.5">
         {/* <SafeArea /> */}
         <LogoHeader />
       </div>

--- a/pick-habju/src/components/Header/AppHeader.tsx
+++ b/pick-habju/src/components/Header/AppHeader.tsx
@@ -18,7 +18,7 @@ const AppHeader = () => {
   return (
     <div className="flex w-full justify-center items-center relative">
       <GoogleFormToast />
-      <div className="flex flex-col w-full max-w-100.5">
+      <div className="flex flex-col w-full max-w-[25.125rem]">
         {/* <SafeArea /> */}
         <LogoHeader />
       </div>

--- a/pick-habju/src/components/Search/NoResultView.tsx
+++ b/pick-habju/src/components/Search/NoResultView.tsx
@@ -3,7 +3,7 @@ import NoResultSvg from '../../assets/svg/NoResult.svg';
 const NoResultView = () => {
   return (
     <div
-      className="flex w-full max-w-[25.9375rem] flex-col justify-center items-start bg-[#FFFBF0]"
+      className="flex w-full max-w-[25.125rem] flex-col justify-center items-start bg-[#FFFBF0]"
       aria-label="No Result Section"
     >
       <div

--- a/pick-habju/src/layout/AppWrapper.tsx
+++ b/pick-habju/src/layout/AppWrapper.tsx
@@ -18,11 +18,9 @@ const AppWrapper = ({ children }: AppWrapperProps) => {
   return (
     <div className="min-h-screen w-full overflow-x-hidden flex justify-center bg-primary-white">
       {/* 컨테이너: 모바일은 100% 폭, 넓은 화면에서는 중앙 정렬 최대폭 */}
-      {/* isWindows: 윈도우는 스크롤바 공간 확보 위해 max-w 26.875rem */}
+      {/* isWindows: 윈도우는 스크롤바 공간 확보 위해 max-w 25.9375rem */}
       <div
-        className={`w-full h-screen flex flex-col bg-primary-white ${
-          isWindows ? 'max-w-[26.875rem]' : 'max-w-[25.9375rem]'
-        }`}
+        className={`w-full h-screen flex flex-col bg-primary-white ${isWindows ? 'max-w-[25.9375rem]' : 'max-w-100.5'}`}
       >
         {/* 헤더(세이프 에어리어 + 로고 헤더) */}
         <AppHeader />

--- a/pick-habju/src/layout/AppWrapper.tsx
+++ b/pick-habju/src/layout/AppWrapper.tsx
@@ -18,9 +18,9 @@ const AppWrapper = ({ children }: AppWrapperProps) => {
   return (
     <div className="min-h-screen w-full overflow-x-hidden flex justify-center bg-primary-white">
       {/* 컨테이너: 모바일은 100% 폭, 넓은 화면에서는 중앙 정렬 최대폭 */}
-      {/* isWindows: 윈도우는 스크롤바 공간 확보 위해 max-w 25.9375rem */}
+      {/* isWindows: 윈도우는 스크롤바 공간 확보 위해 max-w 26.0625rem (417px) */}
       <div
-        className={`w-full h-screen flex flex-col bg-primary-white ${isWindows ? 'max-w-[25.9375rem]' : 'max-w-100.5'}`}
+        className={`w-full h-screen flex flex-col bg-primary-white ${isWindows ? 'max-w-[26.0625rem]' : 'max-w-[25.125rem]'}`}
       >
         {/* 헤더(세이프 에어리어 + 로고 헤더) */}
         <AppHeader />

--- a/pick-habju/src/pages/HomePage.tsx
+++ b/pick-habju/src/pages/HomePage.tsx
@@ -54,7 +54,7 @@ const HomePage = () => {
     <>
       <SEO {...SEO_METADATA.home} url={DEFAULT_SEO.siteUrl} />
       <div className="w-full flex flex-col items-center">
-        <div className="flex w-full max-w-[25.9375rem] flex-col justify-center items-center bg-yellow-300">
+        <div className="flex w-full max-w-[25.125rem] flex-col justify-center items-center bg-yellow-300">
           {/* Hero Area: 날짜, 시간, 인원 선택 */}
           <HeroArea
             key={heroResetCounter}


### PR DESCRIPTION
<!-- 이슈번호를 작성해주세요 -->
Closes #161 

## 특이사항
<!-- 구현 시 고려한 사항이나 주의점이 있다면 작성해주세요 -->
-  footer text 깨짐 및 width 최신화
  - width 402px 로 변경
  - 윈도우 환경 스크롤로 인해 15px 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Footer links reorganized into a single centered horizontal row separated by pipe characters; redundant wrappers and per-link spacing removed for a more compact, cleaner layout. Anchor text and whitespace handling streamlined; focus/ARIA behavior aligned with the new structure.

* **Style**
  * Tightened container max-widths across header, app wrapper, hero and no-result views for a slightly narrower, more consistent responsive layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->