### PR TITLE
Feat/155 marker clustering

### DIFF
--- a/pick-habju/public/lib/naver/MarkerClustering.js
+++ b/pick-habju/public/lib/naver/MarkerClustering.js
@@ -73,12 +73,12 @@ naver.maps.Util.ClassExtend(MarkerClustering, naver.maps.OverlayView, {
   draw: naver.maps.Util.noop,
 
   onRemove: function () {
-    naver.maps.Event.removeListener(this._mapRelation);
+    naver.maps.Event.removeListener(this._mapRelations);
 
     this._clearClusters();
 
     this._geoTree = null;
-    this._mapRelation = null;
+    this._mapRelations = null;
   },
 
   /**
@@ -277,7 +277,7 @@ naver.maps.Util.ClassExtend(MarkerClustering, naver.maps.OverlayView, {
     if (!this.getMap()) return;
 
     switch (key) {
-      case 'marker':
+      case 'markers':
       case 'minClusterSize':
       case 'gridSize':
       case 'averageCenter':

--- a/pick-habju/public/lib/naver/MarkerClustering.js
+++ b/pick-habju/public/lib/naver/MarkerClustering.js
@@ -1,0 +1,755 @@
+/**
+ * Vendored from:
+ * https://github.com/navermaps/marker-tools.js
+ * Path: marker-clustering/src/MarkerClustering.js
+ */
+
+/**
+ * Copyright 2016 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * 마커 클러스터링을 정의합니다.
+ * @param {Object} options 마커 클러스터링 옵션
+ */
+var MarkerClustering = function (options) {
+  // 기본 값입니다.
+  this.DEFAULT_OPTIONS = {
+    // 클러스터 마커를 올릴 지도입니다.
+    map: null,
+    // 클러스터 마커를 구성할 마커입니다.
+    markers: [],
+    // 클러스터 마커 클릭 시 줌 동작 여부입니다.
+    disableClickZoom: true,
+    // 클러스터를 구성할 최소 마커 수입니다.
+    minClusterSize: 2,
+    // 클러스터 마커로 표현할 최대 줌 레벨입니다. 해당 줌 레벨보다 높으면, 클러스터를 구성하고 있는 마커를 노출합니다.
+    maxZoom: 13,
+    // 클러스터를 구성할 그리드 크기입니다. 단위는 픽셀입니다.
+    gridSize: 100,
+    // 클러스터 마커의 아이콘입니다. NAVER Maps JavaScript API v3에서 제공하는 아이콘, 심볼, HTML 마커 유형을 모두 사용할 수 있습니다.
+    icons: [],
+    // 클러스터 마커의 아이콘 배열에서 어떤 아이콘을 선택할 것인지 인덱스를 결정합니다.
+    indexGenerator: [10, 100, 200, 500, 1000],
+    // 클러스터 마커의 위치를 클러스터를 구성하고 있는 마커의 평균 좌표로 할 것인지 여부입니다.
+    averageCenter: false,
+    // 클러스터 마커를 갱신할 때 호출하는 콜백함수입니다. 이 함수를 통해 클러스터 마커에 개수를 표현하는 등의 엘리먼트를 조작할 수 있습니다.
+    stylingFunction: function () {},
+  };
+
+  this._clusters = [];
+
+  this._mapRelations = null;
+  this._markerRelations = [];
+
+  this.setOptions(naver.maps.Util.extend({}, this.DEFAULT_OPTIONS, options), true);
+  this.setMap(options.map || null);
+};
+
+naver.maps.Util.ClassExtend(MarkerClustering, naver.maps.OverlayView, {
+  onAdd: function () {
+    var map = this.getMap();
+
+    this._mapRelations = naver.maps.Event.addListener(map, 'idle', naver.maps.Util.bind(this._onIdle, this));
+
+    if (this.getMarkers().length > 0) {
+      this._createClusters();
+      this._updateClusters();
+    }
+  },
+
+  draw: naver.maps.Util.noop,
+
+  onRemove: function () {
+    naver.maps.Event.removeListener(this._mapRelation);
+
+    this._clearClusters();
+
+    this._geoTree = null;
+    this._mapRelation = null;
+  },
+
+  /**
+   * 마커 클러스터링 옵션을 설정합니다. 설정한 옵션만 반영됩니다.
+   * @param {Object | string} newOptions 옵션
+   */
+  setOptions: function (newOptions) {
+    var _this = this;
+
+    if (typeof newOptions === 'string') {
+      var key = newOptions,
+        value = arguments[1];
+
+      _this.set(key, value);
+    } else {
+      var isFirst = arguments[1];
+
+      naver.maps.Util.forEach(newOptions, function (value, key) {
+        if (key !== 'map') {
+          _this.set(key, value);
+        }
+      });
+
+      if (newOptions.map && !isFirst) {
+        _this.setMap(newOptions.map);
+      }
+    }
+  },
+
+  /**
+   * 마커 클러스터링 옵션을 반환합니다. 특정 옵션 이름을 지정하지 않으면, 모든 옵션을 반환합니다.
+   * @param {string} key 반환받을 옵션 이름
+   * @return {Any} 옵션
+   */
+  getOptions: function (key) {
+    var _this = this,
+      options = {};
+
+    if (key !== undefined) {
+      return _this.get(key);
+    } else {
+      naver.maps.Util.forEach(_this.DEFAULT_OPTIONS, function (value, key) {
+        options[key] = _this.get(key);
+      });
+
+      return options;
+    }
+  },
+
+  /**
+   * 클러스터를 구성하는 최소 마커 수를 반환합니다.
+   * @return {number} 클러스터를 구성하는 최소 마커 수
+   */
+  getMinClusterSize: function () {
+    return this.getOptions('minClusterSize');
+  },
+
+  /**
+   * 클러스터를 구성하는 최소 마커 수를 설정합니다.
+   * @param {number} size 클러스터를 구성하는 최소 마커 수
+   */
+  setMinClusterSize: function (size) {
+    this.setOptions('minClusterSize', size);
+  },
+
+  /**
+   * 클러스터 마커를 노출할 최대 줌 레벨을 반환합니다.
+   * @return {number} 클러스터 마커를 노출할 최대 줌 레벨
+   */
+  getMaxZoom: function () {
+    return this.getOptions('maxZoom');
+  },
+
+  /**
+   * 클러스터 마커를 노출할 최대 줌 레벨을 설정합니다.
+   * @param {number} zoom 클러스터 마커를 노출할 최대 줌 레벨
+   */
+  setMaxZoom: function (zoom) {
+    this.setOptions('maxZoom', zoom);
+  },
+
+  /**
+   * 클러스터를 구성할 그리드 크기를 반환합니다. 단위는 픽셀입니다.
+   * @return {number} 클러스터를 구성할 그리드 크기
+   */
+  getGridSize: function () {
+    return this.getOptions('gridSize');
+  },
+
+  /**
+   * 클러스터를 구성할 그리드 크기를 설정합니다. 단위는 픽셀입니다.
+   * @param {number} size 클러스터를 구성할 그리드 크기
+   */
+  setGridSize: function (size) {
+    this.setOptions('gridSize', size);
+  },
+
+  /**
+   * 클러스터 마커의 아이콘을 결정하는 인덱스 생성기를 반환합니다.
+   * @return {Array | Function} 인덱스 생성기
+   */
+  getIndexGenerator: function () {
+    return this.getOptions('indexGenerator');
+  },
+
+  /**
+   * 클러스터 마커의 아이콘을 결정하는 인덱스 생성기를 설정합니다.
+   * @param {Array | Function} indexGenerator 인덱스 생성기
+   */
+  setIndexGenerator: function (indexGenerator) {
+    this.setOptions('indexGenerator', indexGenerator);
+  },
+
+  /**
+   * 클러스터로 구성할 마커를 반환합니다.
+   * @return {Array.<naver.maps.Marker>} 클러스터로 구성할 마커
+   */
+  getMarkers: function () {
+    return this.getOptions('markers');
+  },
+
+  /**
+   * 클러스터로 구성할 마커를 설정합니다.
+   * @param {Array.<naver.maps.Marker>} markers 클러스터로 구성할 마커
+   */
+  setMarkers: function (markers) {
+    this.setOptions('markers', markers);
+  },
+
+  /**
+   * 클러스터 마커 아이콘을 반환합니다.
+   * @return {Array.<naver.maps.Marker~ImageIcon | naver.maps.Marker~SymbolIcon | naver.maps.Marker~HtmlIcon>} 클러스터 마커 아이콘
+   */
+  getIcons: function () {
+    return this.getOptions('icons');
+  },
+
+  /**
+   * 클러스터 마커 아이콘을 설정합니다.
+   * @param {Array.<naver.maps.Marker~ImageIcon | naver.maps.Marker~SymbolIcon | naver.maps.Marker~HtmlIcon>} icons 클러스터 마커 아이콘
+   */
+  setIcons: function (icons) {
+    this.setOptions('icons', icons);
+  },
+
+  /**
+   * 클러스터 마커의 엘리먼트를 조작할 수 있는 스타일링 함수를 반환합니다.
+   * @return {Funxtion} 콜백함수
+   */
+  getStylingFunction: function () {
+    return this.getOptions('stylingFunction');
+  },
+
+  /**
+   * 클러스터 마커의 엘리먼트를 조작할 수 있는 스타일링 함수를 설정합니다.
+   * @param {Function} func 콜백함수
+   */
+  setStylingFunction: function (func) {
+    this.setOptions('stylingFunction', func);
+  },
+
+  /**
+   * 클러스터 마커를 클릭했을 때 줌 동작 수행 여부를 반환합니다.
+   * @return {boolean} 줌 동작 수행 여부
+   */
+  getDisableClickZoom: function () {
+    return this.getOptions('disableClickZoom');
+  },
+
+  /**
+   * 클러스터 마커를 클릭했을 때 줌 동작 수행 여부를 설정합니다.
+   * @param {boolean} flag 줌 동작 수행 여부
+   */
+  setDisableClickZoom: function (flag) {
+    this.setOptions('disableClickZoom', flag);
+  },
+
+  /**
+   * 클러스터 마커의 위치를 클러스터를 구성하고 있는 마커의 평균 좌표로 할 것인지 여부를 반환합니다.
+   * @return {boolean} 평균 좌표로 클러스터링 여부
+   */
+  getAverageCenter: function () {
+    return this.getOptions('averageCenter');
+  },
+
+  /**
+   * 클러스터 마커의 위치를 클러스터를 구성하고 있는 마커의 평균 좌표로 할 것인지 여부를 설정합니다.
+   * @param {boolean} averageCenter 평균 좌표로 클러스터링 여부
+   */
+  setAverageCenter: function (averageCenter) {
+    this.setOptions('averageCenter', averageCenter);
+  },
+
+  // KVO 이벤트 핸들러
+  changed: function (key, value) {
+    if (!this.getMap()) return;
+
+    switch (key) {
+      case 'marker':
+      case 'minClusterSize':
+      case 'gridSize':
+      case 'averageCenter':
+        this._redraw();
+        break;
+      case 'indexGenerator':
+      case 'icons':
+        this._clusters.forEach(function (cluster) {
+          cluster.updateIcon();
+        });
+        break;
+      case 'maxZoom':
+        this._clusters.forEach(function (cluster) {
+          if (cluster.getCount() > 1) {
+            cluster.checkByZoomAndMinClusterSize();
+          }
+        });
+        break;
+      case 'stylingFunction':
+        this._clusters.forEach(function (cluster) {
+          cluster.updateCount();
+        });
+        break;
+      case 'disableClickZoom':
+        var exec = 'enableClickZoom';
+
+        if (value) {
+          exec = 'disableClickZoom';
+        }
+
+        this._clusters.forEach(function (cluster) {
+          cluster[exec]();
+        });
+        break;
+    }
+  },
+
+  /**
+   * 현재 지도 경계 영역 내의 마커에 대해 클러스터를 생성합니다.
+   * @private
+   */
+  _createClusters: function () {
+    var map = this.getMap();
+
+    if (!map) return;
+
+    var bounds = map.getBounds(),
+      markers = this.getMarkers();
+
+    for (var i = 0, ii = markers.length; i < ii; i++) {
+      var marker = markers[i],
+        position = marker.getPosition();
+
+      if (!bounds.hasLatLng(position)) continue;
+
+      var closestCluster = this._getClosestCluster(position);
+
+      closestCluster.addMarker(marker);
+
+      this._markerRelations.push(
+        naver.maps.Event.addListener(marker, 'dragend', naver.maps.Util.bind(this._onDragEnd, this))
+      );
+    }
+  },
+
+  /**
+   * 클러스터의 아이콘, 텍스트를 갱신합니다.
+   * @private
+   */
+  _updateClusters: function () {
+    var clusters = this._clusters;
+
+    for (var i = 0, ii = clusters.length; i < ii; i++) {
+      clusters[i].updateCluster();
+    }
+  },
+
+  /**
+   * 클러스터를 모두 제거합니다.
+   * @private
+   */
+  _clearClusters: function () {
+    var clusters = this._clusters;
+
+    for (var i = 0, ii = clusters.length; i < ii; i++) {
+      clusters[i].destroy();
+    }
+
+    naver.maps.Event.removeListener(this._markerRelations);
+
+    this._markerRelations = [];
+    this._clusters = [];
+  },
+
+  /**
+   * 생성된 클러스터를 모두 제거하고, 다시 생성합니다.
+   * @private
+   */
+  _redraw: function () {
+    this._clearClusters();
+    this._createClusters();
+    this._updateClusters();
+  },
+
+  /**
+   * 전달된 위/경도에서 가장 가까운 클러스터를 반환합니다. 없으면 새로 클러스터를 생성해 반환합니다.
+   * @param {naver.maps.LatLng} position 위/경도
+   * @return {Cluster} 클러스터
+   */
+  _getClosestCluster: function (position) {
+    var proj = this.getProjection(),
+      clusters = this._clusters,
+      closestCluster = null,
+      distance = Infinity;
+
+    for (var i = 0, ii = clusters.length; i < ii; i++) {
+      var cluster = clusters[i],
+        center = cluster.getCenter();
+
+      if (cluster.isInBounds(position)) {
+        var delta = proj.getDistance(center, position);
+
+        if (delta < distance) {
+          distance = delta;
+          closestCluster = cluster;
+        }
+      }
+    }
+
+    if (!closestCluster) {
+      closestCluster = new Cluster(this);
+      this._clusters.push(closestCluster);
+    }
+
+    return closestCluster;
+  },
+
+  /**
+   * 지도의 Idle 상태 이벤트 핸들러입니다.
+   */
+  _onIdle: function () {
+    this._redraw();
+  },
+
+  /**
+   * 각 마커의 드래그 종료 이벤트 핸들러입니다.
+   */
+  _onDragEnd: function () {
+    this._redraw();
+  },
+});
+
+/**
+ * 마커를 가지고 있는 클러스터를 정의합니다.
+ * @param {MarkerClustering} markerClusterer
+ */
+var Cluster = function (markerClusterer) {
+  this._clusterCenter = null;
+  this._clusterBounds = null;
+  this._clusterMarker = null;
+  this._relation = null;
+
+  this._clusterMember = [];
+
+  this._markerClusterer = markerClusterer;
+};
+
+Cluster.prototype = {
+  constructor: Cluster,
+
+  /**
+   * 클러스터에 마커를 추가합니다.
+   * @param {naver.maps.Marker} marker 클러스터에 추가할 마커
+   */
+  addMarker: function (marker) {
+    if (this._isMember(marker)) return;
+
+    if (!this._clusterCenter) {
+      var position = marker.getPosition();
+
+      this._clusterCenter = position;
+      this._clusterBounds = this._calcBounds(position);
+    }
+
+    this._clusterMember.push(marker);
+  },
+
+  /**
+   * 클러스터를 제거합니다.
+   */
+  destroy: function () {
+    naver.maps.Event.removeListener(this._relation);
+
+    var members = this._clusterMember;
+
+    for (var i = 0, ii = members.length; i < ii; i++) {
+      members[i].setMap(null);
+    }
+
+    this._clusterMarker.setMap(null);
+
+    this._clusterMarker = null;
+    this._clusterCenter = null;
+    this._clusterBounds = null;
+    this._relation = null;
+
+    this._clusterMember = [];
+  },
+
+  /**
+   * 클러스터 중심점을 반환합니다.
+   * @return {naver.maps.LatLng} 클러스터 중심점
+   */
+  getCenter: function () {
+    return this._clusterCenter;
+  },
+
+  /**
+   * 클러스터 경계 영역을 반환합니다.
+   * @return {naver.maps.LatLngBounds} 클러스터 경계 영역
+   */
+  getBounds: function () {
+    return this._clusterBounds;
+  },
+
+  /**
+   * 클러스터를 구성하는 마커 수를 반환합니다.
+   * @return {number} 클러스터를 구성하는 마커 수
+   */
+  getCount: function () {
+    return this._clusterMember.length;
+  },
+
+  /**
+   * 현재의 클러스터 멤버 마커 객체를 반환합니다.
+   * @return {naver.maps.Marker[]} 클러스터를 구성하는 마커 객체 집합
+   */
+  getClusterMember: function () {
+    return this._clusterMember;
+  },
+
+  /**
+   * 전달된 위/경도가 클러스터 경계 영역 내에 있는지 여부를 반환합니다.
+   * @param {naver.maps.LatLng} latlng 위/경도
+   * @return {boolean} 클러스터 경계 영역 내의 위치 여부
+   */
+  isInBounds: function (latlng) {
+    return this._clusterBounds && this._clusterBounds.hasLatLng(latlng);
+  },
+
+  /**
+   * 클러스터 마커 클릭 시 줌 동작을 수행하도록 합니다.
+   */
+  enableClickZoom: function () {
+    if (this._relation) return;
+
+    var map = this._markerClusterer.getMap();
+
+    this._relation = naver.maps.Event.addListener(
+      this._clusterMarker,
+      'click',
+      naver.maps.Util.bind(function (e) {
+        map.morph(e.coord, map.getZoom() + 1);
+      }, this)
+    );
+  },
+
+  /**
+   * 클러스터 마커 클릭 시 줌 동작을 수행하지 않도록 합니다.
+   */
+  disableClickZoom: function () {
+    if (!this._relation) return;
+
+    naver.maps.Event.removeListener(this._relation);
+    this._relation = null;
+  },
+
+  /**
+   * 클러스터 마커가 없으면 클러스터 마커를 생성하고, 클러스터 마커를 갱신합니다.
+   * - 클러스터 마커 아이콘
+   * - 마커 개수
+   * - 클러스터 마커 노출 여부
+   */
+  updateCluster: function () {
+    if (!this._clusterMarker) {
+      var position;
+
+      if (this._markerClusterer.getAverageCenter()) {
+        position = this._calcAverageCenter(this._clusterMember);
+      } else {
+        position = this._clusterCenter;
+      }
+
+      this._clusterMarker = new naver.maps.Marker({
+        position: position,
+        map: this._markerClusterer.getMap(),
+      });
+
+      if (!this._markerClusterer.getDisableClickZoom()) {
+        this.enableClickZoom();
+      }
+    }
+
+    this.updateIcon();
+    this.updateCount();
+
+    this.checkByZoomAndMinClusterSize();
+  },
+
+  /**
+   * 조건에 따라 클러스터 마커를 노출하거나, 노출하지 않습니다.
+   */
+  checkByZoomAndMinClusterSize: function () {
+    var clusterer = this._markerClusterer,
+      minClusterSize = clusterer.getMinClusterSize(),
+      maxZoom = clusterer.getMaxZoom(),
+      currentZoom = clusterer.getMap().getZoom();
+
+    if (this.getCount() < minClusterSize) {
+      this._showMember();
+    } else {
+      this._hideMember();
+
+      if (maxZoom <= currentZoom) {
+        this._showMember();
+      }
+    }
+  },
+
+  /**
+   * 클러스터를 구성하는 마커 수를 갱신합니다.
+   */
+  updateCount: function () {
+    var stylingFunction = this._markerClusterer.getStylingFunction();
+
+    stylingFunction && stylingFunction(this._clusterMarker, this.getCount());
+  },
+
+  /**
+   * 클러스터 마커 아이콘을 갱신합니다.
+   */
+  updateIcon: function () {
+    var count = this.getCount(),
+      index = this._getIndex(count),
+      icons = this._markerClusterer.getIcons();
+
+    index = Math.max(index, 0);
+    index = Math.min(index, icons.length - 1);
+
+    this._clusterMarker.setIcon(icons[index]);
+  },
+
+  /**
+   * 클러스터를 구성하는 마커를 노출합니다. 이때에는 클러스터 마커를 노출하지 않습니다.
+   * @private
+   */
+  _showMember: function () {
+    var map = this._markerClusterer.getMap(),
+      marker = this._clusterMarker,
+      members = this._clusterMember;
+
+    for (var i = 0, ii = members.length; i < ii; i++) {
+      members[i].setMap(map);
+    }
+
+    if (marker) {
+      marker.setMap(null);
+    }
+  },
+
+  /**
+   * 클러스터를 구성하는 마커를 노출하지 않습니다. 이때에는 클러스터 마커를 노출합니다.
+   * @private
+   */
+  _hideMember: function () {
+    var map = this._markerClusterer.getMap(),
+      marker = this._clusterMarker,
+      members = this._clusterMember;
+
+    for (var i = 0, ii = members.length; i < ii; i++) {
+      members[i].setMap(null);
+    }
+
+    if (marker && !marker.getMap()) {
+      marker.setMap(map);
+    }
+  },
+
+  /**
+   * 전달된 위/경도를 중심으로 그리드 크기만큼 확장한 클러스터 경계 영역을 반환합니다.
+   * @param {naver.maps.LatLng} position 위/경도
+   * @return {naver.maps.LatLngBounds} 클러스터 경계 영역
+   * @private
+   */
+  _calcBounds: function (position) {
+    var map = this._markerClusterer.getMap(),
+      bounds = new naver.maps.LatLngBounds(position.clone(), position.clone()),
+      mapBounds = map.getBounds(),
+      proj = map.getProjection(),
+      map_max_px = proj.fromCoordToOffset(mapBounds.getNE()),
+      map_min_px = proj.fromCoordToOffset(mapBounds.getSW()),
+      max_px = proj.fromCoordToOffset(bounds.getNE()),
+      min_px = proj.fromCoordToOffset(bounds.getSW()),
+      gridSize = this._markerClusterer.getGridSize() / 2;
+
+    max_px.add(gridSize, -gridSize);
+    min_px.add(-gridSize, gridSize);
+
+    var max_px_x = Math.min(map_max_px.x, max_px.x),
+      max_px_y = Math.max(map_max_px.y, max_px.y),
+      min_px_x = Math.max(map_min_px.x, min_px.x),
+      min_px_y = Math.min(map_min_px.y, min_px.y),
+      newMax = proj.fromOffsetToCoord(new naver.maps.Point(max_px_x, max_px_y)),
+      newMin = proj.fromOffsetToCoord(new naver.maps.Point(min_px_x, min_px_y));
+
+    return new naver.maps.LatLngBounds(newMin, newMax);
+  },
+
+  /**
+   * 클러스터를 구성하는 마커 수에 따라 노출할 아이콘을 결정하기 위한 인덱스를 반환합니다.
+   * @param {number} count 클러스터를 구성하는 마커 수
+   * @return {number} 인덱스
+   * @private
+   */
+  _getIndex: function (count) {
+    var indexGenerator = this._markerClusterer.getIndexGenerator();
+
+    if (naver.maps.Util.isFunction(indexGenerator)) {
+      return indexGenerator(count);
+    } else if (naver.maps.Util.isArray(indexGenerator)) {
+      var index = 0;
+
+      for (var i = index, ii = indexGenerator.length; i < ii; i++) {
+        var factor = indexGenerator[i];
+
+        if (count < factor) break;
+
+        index++;
+      }
+
+      return index;
+    }
+  },
+
+  /**
+   * 전달된 마커가 이미 클러스터에 속해 있는지 여부를 반환합니다.
+   * @param {naver.maps.Marker} marker 마커
+   * @return {boolean} 클러스터에 속해 있는지 여부
+   * @private
+   */
+  _isMember: function (marker) {
+    return this._clusterMember.indexOf(marker) !== -1;
+  },
+
+  /**
+   * 전달된 마커들의 중심 좌표를 반환합니다.
+   * @param {Array.<naver.maps.Marker>} markers 마커 배열
+   * @return {naver.maps.Point} 마커들의 중심 좌표
+   * @private
+   */
+  _calcAverageCenter: function (markers) {
+    var numberOfMarkers = markers.length;
+    var averageCenter = [0, 0];
+
+    for (var i = 0; i < numberOfMarkers; i++) {
+      averageCenter[0] += markers[i].position.x;
+      averageCenter[1] += markers[i].position.y;
+    }
+
+    averageCenter[0] /= numberOfMarkers;
+    averageCenter[1] /= numberOfMarkers;
+
+    return new naver.maps.Point(averageCenter[0], averageCenter[1]);
+  },
+};

--- a/pick-habju/src/components/Map/NaverMap.tsx
+++ b/pick-habju/src/components/Map/NaverMap.tsx
@@ -5,7 +5,7 @@ import PriceList from '../Price/PriceList/PriceList';
 import type { MarkerViewModel, MapViewport, NaverMapHandle } from '../../types/map';
 import { getViewportFromMap } from '../../utils/naverMapAdapter';
 import { loadNaverMapScript } from '../../utils/loadNaverMapScript';
-import { getClusterIcons } from '../../hook/useGetClusterIcon';
+import { getClusterIcons } from '../../hook/getClusterIcons';
 
 /** NaverMap 컴포넌트 Props. */
 type NaverMapProps = {

--- a/pick-habju/src/components/Map/NaverMap.tsx
+++ b/pick-habju/src/components/Map/NaverMap.tsx
@@ -5,6 +5,7 @@ import PriceList from '../Price/PriceList/PriceList';
 import type { MarkerViewModel, MapViewport, NaverMapHandle } from '../../types/map';
 import { getViewportFromMap } from '../../utils/naverMapAdapter';
 import { loadNaverMapScript } from '../../utils/loadNaverMapScript';
+import { getClusterIcons } from '../../hook/useGetClusterIcon';
 
 /** NaverMap 컴포넌트 Props. */
 type NaverMapProps = {
@@ -92,6 +93,8 @@ const NaverMap = forwardRef<NaverMapHandle, NaverMapProps>(
     const markerInstancesRef = useRef<Map<string, naver.maps.Marker>>(new Map());
     const markerListenersRef = useRef<naver.maps.MapEventListener[]>([]);
     const prevSelectedMarkerIdRef = useRef<string | null>(null);
+    /** MarkerClustering 인스턴스. markerViewModels 변경 시 재생성. */
+    const clusteringRef = useRef<MarkerClustering | null>(null);
     // 마커 클릭 핸들러에서 현재 openedMarkerPopoverId를 읽기 위한 ref.
     // 클로저 생성 시점의 값을 캡처하므로 직접 prop을 참조할 수 없음.
     const openedMarkerPopoverIdRef = useRef<string | null>(null);
@@ -200,6 +203,11 @@ const NaverMap = forwardRef<NaverMapHandle, NaverMapProps>(
       return () => {
         cancelled = true;
 
+        if (clusteringRef.current) {
+          clusteringRef.current.setMap(null);
+          clusteringRef.current = null;
+        }
+
         for (const listener of markerListenersRef.current) {
           naver.maps.Event.removeListener(listener);
         }
@@ -239,8 +247,15 @@ const NaverMap = forwardRef<NaverMapHandle, NaverMapProps>(
     // markerViewModels 변경 시 마커 전체 재생성.
     // 단일 룸 마커: 클릭 시 바로 룸 선택.
     // 복수 룸 마커: 클릭 시 팝오버 토글.
+    // MarkerClustering이 로드된 경우 클러스터링 인스턴스도 재생성.
     useEffect(() => {
       if (!isMapReady) return;
+
+      // 이전 클러스터링 인스턴스 제거
+      if (clusteringRef.current) {
+        clusteringRef.current.setMap(null);
+        clusteringRef.current = null;
+      }
 
       for (const listener of markerListenersRef.current) {
         naver.maps.Event.removeListener(listener);
@@ -256,10 +271,13 @@ const NaverMap = forwardRef<NaverMapHandle, NaverMapProps>(
       if (!map) return;
 
       const models = markerViewModels ?? [];
+      const markerArray: naver.maps.Marker[] = [];
+
       for (const model of models) {
+        // MarkerClustering이 마커 가시성(setMap)을 관리하므로 map 속성 없이 생성.
+        // 클러스터링 미사용 폴백 시에는 아래에서 직접 setMap을 호출한다.
         const marker = new naver.maps.Marker({
           position: new naver.maps.LatLng(model.lat, model.lng),
-          map,
           zIndex: model.favorite === 'on' ? 1 : 0,
           icon: {
             content: renderToStaticMarkup(
@@ -275,6 +293,7 @@ const NaverMap = forwardRef<NaverMapHandle, NaverMapProps>(
           },
         });
 
+        markerArray.push(marker);
         markerInstancesRef.current.set(model.id, marker);
         markerListenersRef.current.push(
           naver.maps.Event.addListener(marker, 'click', () => {
@@ -303,6 +322,34 @@ const NaverMap = forwardRef<NaverMapHandle, NaverMapProps>(
             onMarkerClickRef.current?.(model.id);
           })
         );
+      }
+
+      // MarkerClustering 적용.
+      // 클러스터링 라이브러리가 로드된 경우 MarkerClustering 인스턴스를 생성하고
+      // 마커 가시성 관리를 위임한다. 미로드 시 마커를 직접 지도에 설정하여 폴백.
+      if (typeof MarkerClustering !== 'undefined' && markerArray.length > 0) {
+        const { htmlMarker1, htmlMarker2, htmlMarker3 } = getClusterIcons(naver.maps);
+        clusteringRef.current = new MarkerClustering({
+          map,
+          markers: markerArray,
+          minClusterSize: 2,
+          // 이 줌 레벨 이상에서는 클러스터를 해제하고 개별 마커를 표시
+          maxZoom: 14,
+          gridSize: 120,
+          disableClickZoom: false,
+          icons: [htmlMarker1, htmlMarker2, htmlMarker3],
+          // [5, 14] → 1~5개: htmlMarker1, 6~14개: htmlMarker2, 15개+: htmlMarker3
+          indexGenerator: [5, 14],
+          stylingFunction: (clusterMarker, count) => {
+            const el = clusterMarker.getElement()?.querySelector('div');
+            if (el) (el as HTMLElement).textContent = String(count);
+          },
+        });
+      } else {
+        // 폴백: MarkerClustering 없이 개별 마커를 지도에 직접 표시
+        for (const marker of markerArray) {
+          marker.setMap(map);
+        }
       }
     }, [isMapReady, markerViewModels]);
 

--- a/pick-habju/src/components/Map/NaverMap.tsx
+++ b/pick-habju/src/components/Map/NaverMap.tsx
@@ -334,7 +334,7 @@ const NaverMap = forwardRef<NaverMapHandle, NaverMapProps>(
           markers: markerArray,
           minClusterSize: 2,
           // 이 줌 레벨 이상에서는 클러스터를 해제하고 개별 마커를 표시
-          maxZoom: 14,
+          maxZoom: 15,
           gridSize: 120,
           disableClickZoom: false,
           icons: [htmlMarker1, htmlMarker2, htmlMarker3],

--- a/pick-habju/src/hook/getClusterIcons.ts
+++ b/pick-habju/src/hook/getClusterIcons.ts
@@ -31,7 +31,7 @@ const createClusterContent = (
   return `<div class="cluster-icon cluster-icon--${variant}" style="cursor:pointer;width:${size}px;height:${size}px;line-height:${size}px;font-size:18px;font-family:'Pretendard',sans-serif;font-weight:700;color:#fff;text-align:center;letter-spacing:0.54px;border-radius:50%;${opacityStyle}"></div>`;
 };
 
-export const useGetClusterIcon = (navermaps: typeof naver.maps) => {
+export const getClusterIcons = (navermaps: typeof naver.maps) => {
   const { small, medium, large } = CLUSTER_STYLES;
 
   const htmlMarker1 = {
@@ -54,10 +54,3 @@ export const useGetClusterIcon = (navermaps: typeof naver.maps) => {
 
   return { htmlMarker1, htmlMarker2, htmlMarker3 };
 };
-
-/**
- * useGetClusterIcon의 별칭.
- * useEffect 등 훅 컨텍스트 외부에서 호출할 때 사용.
- * (내부에 React 훅을 사용하지 않으므로 어디서든 안전하게 호출 가능)
- */
-export const getClusterIcons = useGetClusterIcon;

--- a/pick-habju/src/hook/useGetClusterIcon.ts
+++ b/pick-habju/src/hook/useGetClusterIcon.ts
@@ -1,13 +1,5 @@
-// TODO: @types/navermaps 설치 후 NaverMapsLike 인터페이스를 제거하고,
-// useGetClusterIcon 파라미터 타입을 typeof naver.maps 로 변경할 것.
-/** useNavermaps() 훅이 반환하는 navermaps 객체에서 실제 사용하는 부분만 정의 */
-interface NaverMapsLike {
-  Size: new (width: number, height: number) => unknown;
-  Point: new (x: number, y: number) => unknown;
-}
-
 /**
- * 네이버 지도 마커 클러스터링에 사용되는 아이콘을 생성하는 훅
+ * 네이버 지도 마커 클러스터링에 사용되는 아이콘을 생성하는 함수.
  *
  * 클러스터 아이콘은 마커 개수에 따라 3단계로 구분됩니다:
  * - htmlMarker1: 1~5개 (50px → 호버 60px)
@@ -16,7 +8,7 @@ interface NaverMapsLike {
  *
  * 스타일은 src/index.css에 전역으로 정의되어 있습니다.
  *
- * @param navermaps - naver.maps 네임스페이스 객체 (useNavermaps() 반환값)
+ * @param navermaps - naver.maps 네임스페이스 객체
  * @returns 클러스터 아이콘 마커 설정 객체 3개
  */
 
@@ -39,7 +31,7 @@ const createClusterContent = (
   return `<div class="cluster-icon cluster-icon--${variant}" style="cursor:pointer;width:${size}px;height:${size}px;line-height:${size}px;font-size:18px;font-family:'Pretendard',sans-serif;font-weight:700;color:#fff;text-align:center;letter-spacing:0.54px;border-radius:50%;${opacityStyle}"></div>`;
 };
 
-export const useGetClusterIcon = (navermaps: NaverMapsLike) => {
+export const useGetClusterIcon = (navermaps: typeof naver.maps) => {
   const { small, medium, large } = CLUSTER_STYLES;
 
   const htmlMarker1 = {
@@ -62,3 +54,10 @@ export const useGetClusterIcon = (navermaps: NaverMapsLike) => {
 
   return { htmlMarker1, htmlMarker2, htmlMarker3 };
 };
+
+/**
+ * useGetClusterIcon의 별칭.
+ * useEffect 등 훅 컨텍스트 외부에서 호출할 때 사용.
+ * (내부에 React 훅을 사용하지 않으므로 어디서든 안전하게 호출 가능)
+ */
+export const getClusterIcons = useGetClusterIcon;

--- a/pick-habju/src/types/naver.d.ts
+++ b/pick-habju/src/types/naver.d.ts
@@ -48,7 +48,7 @@ declare global {
 
   /**
    * 네이버 지도 MarkerClustering 유틸리티 라이브러리.
-   * CDN: https://cdn.jsdelivr.net/gh/navermaps/marker-tools.js@master/marker-clustering/src/MarkerClustering.js
+   * vendored: public/lib/naver/MarkerClustering.js
    */
   class MarkerClustering {
     constructor(options: MarkerClusteringOptions);

--- a/pick-habju/src/types/naver.d.ts
+++ b/pick-habju/src/types/naver.d.ts
@@ -3,5 +3,59 @@ export {};
 declare global {
   interface Window {
     naver: typeof naver;
+    MarkerClustering?: typeof MarkerClustering;
+  }
+
+  /** MarkerClustering 아이콘 설정 (htmlMarker1/2/3 각각에 전달). */
+  interface MarkerClusteringIcon {
+    content: string;
+    size: naver.maps.Size;
+    anchor: naver.maps.Point;
+  }
+
+  /** MarkerClustering 생성자 옵션. */
+  interface MarkerClusteringOptions {
+    /** 클러스터를 표시할 지도 인스턴스. */
+    map?: naver.maps.Map | null;
+    /** 클러스터링할 마커 배열. */
+    markers?: naver.maps.Marker[];
+    /** 클러스터 클릭 시 줌인 비활성화 여부. */
+    disableClickZoom?: boolean;
+    /** 클러스터를 구성할 최소 마커 수. */
+    minClusterSize?: number;
+    /** 클러스터링을 해제할 줌 레벨. 이 레벨 이상에서는 개별 마커를 표시. */
+    maxZoom?: number;
+    /** 클러스터링 기준 그리드 크기(px). */
+    gridSize?: number;
+    /** 클러스터 마커 개수 단계별 아이콘 배열. indexGenerator 순서에 대응. */
+    icons?: MarkerClusteringIcon[];
+    /**
+     * 클러스터 아이콘 구간 경계값 배열.
+     * [5, 14] 이면 1-5→icons[0], 6-14→icons[1], 15+→icons[2].
+     */
+    indexGenerator?: number[] | ((count: number) => number);
+    /** 클러스터 중심을 평균 좌표로 설정할지 여부. */
+    averageCenter?: boolean;
+    /**
+     * 클러스터 마커 DOM 스타일링 콜백.
+     * clusterMarker.getElement()로 DOM 요소에 접근 가능.
+     */
+    stylingFunction?: (
+      clusterMarker: { getElement: () => Element | null },
+      count: number,
+    ) => void;
+  }
+
+  /**
+   * 네이버 지도 MarkerClustering 유틸리티 라이브러리.
+   * CDN: https://cdn.jsdelivr.net/gh/navermaps/marker-tools.js@master/marker-clustering/src/MarkerClustering.js
+   */
+  class MarkerClustering {
+    constructor(options: MarkerClusteringOptions);
+    setMarkers(markers: naver.maps.Marker[]): void;
+    getMarkers(): naver.maps.Marker[];
+    setMap(map: naver.maps.Map | null): void;
+    getMap(): naver.maps.Map | null;
+    setOptions(options: Partial<MarkerClusteringOptions>): void;
   }
 }

--- a/pick-habju/src/utils/loadNaverMapScript.ts
+++ b/pick-habju/src/utils/loadNaverMapScript.ts
@@ -3,8 +3,8 @@ const SCRIPT_BASE =
   'https://openapi.map.naver.com/openapi/v3/maps.js';
 
 const MARKER_CLUSTERING_SCRIPT_ID = 'naver-maps-clustering-script';
-const MARKER_CLUSTERING_SRC =
-  'https://cdn.jsdelivr.net/gh/navermaps/marker-tools.js@master/marker-clustering/src/MarkerClustering.js';
+// vendored: navermaps/marker-tools.js marker-clustering/src/MarkerClustering.js
+const MARKER_CLUSTERING_SRC = '/lib/naver/MarkerClustering.js';
 
 // 한 번 resolve된 이후 재설정되지 않는다 (의도적 설계).
 // MarkerClustering 로드 실패 시에도 warn 후 resolve하여 캐싱되므로,

--- a/pick-habju/src/utils/loadNaverMapScript.ts
+++ b/pick-habju/src/utils/loadNaverMapScript.ts
@@ -2,17 +2,59 @@ const NAVER_MAP_SCRIPT_ID = 'naver-maps-script';
 const SCRIPT_BASE =
   'https://openapi.map.naver.com/openapi/v3/maps.js';
 
+const MARKER_CLUSTERING_SCRIPT_ID = 'naver-maps-clustering-script';
+const MARKER_CLUSTERING_SRC =
+  'https://cdn.jsdelivr.net/gh/navermaps/marker-tools.js@master/marker-clustering/src/MarkerClustering.js';
+
 let loadPromise: Promise<typeof naver> | null = null;
+
+/**
+ * MarkerClustering.js를 동적으로 로드.
+ * naver maps 스크립트 로드 완료 이후 호출해야 합니다.
+ * 실패 시 reject하지 않고 경고만 출력하여 지도 기능은 유지합니다.
+ */
+function loadMarkerClusteringScript(): Promise<void> {
+  if (window.MarkerClustering) return Promise.resolve();
+
+  const existing = document.getElementById(MARKER_CLUSTERING_SCRIPT_ID);
+  if (existing) {
+    return new Promise((resolve, reject) => {
+      if (window.MarkerClustering) {
+        resolve();
+        return;
+      }
+      existing.addEventListener('load', () => resolve(), { once: true });
+      existing.addEventListener(
+        'error',
+        () => reject(new Error('Failed to load MarkerClustering script')),
+        { once: true },
+      );
+    });
+  }
+
+  return new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.id = MARKER_CLUSTERING_SCRIPT_ID;
+    script.type = 'text/javascript';
+    script.src = MARKER_CLUSTERING_SRC;
+    script.async = true;
+    script.onload = () => resolve();
+    script.onerror = () => reject(new Error('Failed to load MarkerClustering script'));
+    document.head.appendChild(script);
+  });
+}
 
 /**
  * Vite 환경 변수 VITE_NAVER_MAP_CLIENT_ID 로 네이버 지도 스크립트를 동적으로 로드합니다.
  * index.html 에서는 HTML 치환이 되지 않으므로, 여기서 올바른 Client ID 를 넣어 요청해야 인증이 성공합니다.
+ * 지도 스크립트 로드 후 MarkerClustering 스크립트도 연속으로 로드합니다.
+ * MarkerClustering 로드 실패 시 경고를 출력하지만 지도 기능은 유지됩니다.
  */
 export function loadNaverMapScript(): Promise<typeof naver> {
   if (typeof window === 'undefined') {
     return Promise.reject(new Error('Naver Map is not available in SSR'));
   }
-  if (window.naver?.maps) {
+  if (window.naver?.maps && window.MarkerClustering) {
     return Promise.resolve(window.naver);
   }
   if (loadPromise) {
@@ -27,19 +69,25 @@ export function loadNaverMapScript(): Promise<typeof naver> {
       )
     );
   }
-  
+
   const url = `${SCRIPT_BASE}?ncpKeyId=${encodeURIComponent(clientId)}&submodules=geocoder`;
 
   loadPromise = new Promise((resolve, reject) => {
+    const afterNaverLoaded = () => {
+      loadMarkerClusteringScript()
+        .then(() => resolve(window.naver))
+        .catch((err) => {
+          console.warn('[NaverMap] MarkerClustering 스크립트 로드 실패. 클러스터링 없이 동작합니다.', err);
+          resolve(window.naver);
+        });
+    };
+
     const existing = document.getElementById(NAVER_MAP_SCRIPT_ID);
     if (existing) {
-      if (window.naver?.maps) resolve(window.naver);
-      else {
-        existing.addEventListener(
-          'load',
-          () => resolve(window.naver),
-          { once: true }
-        );
+      if (window.naver?.maps) {
+        afterNaverLoaded();
+      } else {
+        existing.addEventListener('load', afterNaverLoaded, { once: true });
         existing.addEventListener(
           'error',
           () => reject(new Error('Failed to load Naver Map script')),
@@ -48,12 +96,13 @@ export function loadNaverMapScript(): Promise<typeof naver> {
       }
       return;
     }
+
     const script = document.createElement('script');
     script.id = NAVER_MAP_SCRIPT_ID;
     script.type = 'text/javascript';
     script.src = url;
     script.async = true;
-    script.onload = () => resolve(window.naver);
+    script.onload = afterNaverLoaded;
     script.onerror = () =>
       reject(new Error('Failed to load Naver Map script'));
     document.head.appendChild(script);

--- a/pick-habju/src/utils/loadNaverMapScript.ts
+++ b/pick-habju/src/utils/loadNaverMapScript.ts
@@ -6,6 +6,9 @@ const MARKER_CLUSTERING_SCRIPT_ID = 'naver-maps-clustering-script';
 const MARKER_CLUSTERING_SRC =
   'https://cdn.jsdelivr.net/gh/navermaps/marker-tools.js@master/marker-clustering/src/MarkerClustering.js';
 
+// 한 번 resolve된 이후 재설정되지 않는다 (의도적 설계).
+// MarkerClustering 로드 실패 시에도 warn 후 resolve하여 캐싱되므로,
+// 실패 후 재시도는 지원하지 않는다. 필요 시 페이지 새로고침으로 재시도.
 let loadPromise: Promise<typeof naver> | null = null;
 
 /**
@@ -54,6 +57,9 @@ export function loadNaverMapScript(): Promise<typeof naver> {
   if (typeof window === 'undefined') {
     return Promise.reject(new Error('Naver Map is not available in SSR'));
   }
+  // loadPromise가 없는 상태에서 두 스크립트가 외부(예: index.html)에 의해
+  // 이미 로드된 경우 loadPromise 생성 없이 즉시 반환.
+  // loadPromise가 이미 존재하면 아래의 캐시 반환에서 처리되므로 이 분기는 실행되지 않는다.
   if (window.naver?.maps && window.MarkerClustering) {
     return Promise.resolve(window.naver);
   }


### PR DESCRIPTION
<!-- 이슈번호를 작성해주세요 -->
Closes #155 

## 특이사항
<!-- 구현 시 고려한 사항이나 주의점이 있다면 작성해주세요 -->
- 마커 클러스터링 줌 레벨은 초기 zoom 레벨보다 한단계 넓은 15로 설정.
- 네이버 공식 클러스터링 라이브러리가 소스 파일만 제공됨. 런타임에 동적 로드하고, window.MarkerClustering 전역 클래스로 사용.
- 마커 클러스터링이 마커 가시성 제어하므로 map 속성 없이 마커 생성하고 MarkerClustering이 줌 레벨에 따라 setMap() 직접 제어

## 구현 내용
### naver.d.ts
MarkerClustering 전역 클래스 타입 선언
Window.MarkerClustering 확장

### useGetClusterIcon.ts
임시 인터페이스 NaverMapsLike 제거, 파라미터 타입 typeof naver.maps로 교체

### loadNaverMapScript.ts
loadMarkerClusteringScript() 추가: 네이버 지도 스크립트 로드 완료 후 MarkerClustering.js를 연속 로드
로드 실패 시 console.warn만 출력하도록 하고 지도는 정상 작동

### NaverMap.tsx
clusteringRef ref 추가
마커 생성 시 map 속성 제거
MarkerClustering 생성 옵션:
- maxZoom: 15 — 줌 15 이하 클러스터링, 16 이상(기본 줌) 개별 마커
- gridSize: 120 — 120px 이내 마커 묶음
- indexGenerator: [5, 14] — useGetClusterIcon의 3단계 아이콘 구간과 일치
- stylingFunction — 클러스터 아이콘 div에 마커 개수 텍스트 주입


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Marker clustering on the map to group nearby markers, showing cluster icons with counts and expanding by zoom.
  * Customizable cluster appearance and behavior (icons, sizing, zoom thresholds, average-center handling).
  * Graceful fallback when clustering support isn't available so markers still display.

* **Chores**
  * Map initialization and lifecycle updated to initialize, update, and clean up clustering reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->