### PR TITLE
[#179]; QA: hover 가능 기기에서만 hover 동작하게

### DIFF
--- a/pick-habju/src/components/DatePicker/DateNum/DateNumStyles.ts
+++ b/pick-habju/src/components/DatePicker/DateNum/DateNumStyles.ts
@@ -4,7 +4,7 @@ export const dateNumVariants = {
   empty: 'text-gray-300 cursor-default',
   selected: 'bg-yellow-900 text-primary-black',
   today:
-    'text-primary-black border border-gray-600 [@media(hover:hover)]:hover:border-none [@media(hover:hover)]:hover:bg-yellow-700',
+    'text-primary-black border border-gray-600 [@media(hover:hover)_and_(pointer:fine)]:hover:border-none [@media(hover:hover)_and_(pointer:fine)]:hover:bg-yellow-700',
   past: 'text-gray-300 cursor-not-allowed',
-  available: 'text-primary-black [@media(hover:hover)]:hover:bg-yellow-700 cursor-pointer',
+  available: 'text-primary-black [@media(hover:hover)_and_(pointer:fine)]:hover:bg-yellow-700 cursor-pointer',
 };

--- a/pick-habju/src/components/DatePicker/DateNum/DateNumStyles.ts
+++ b/pick-habju/src/components/DatePicker/DateNum/DateNumStyles.ts
@@ -3,7 +3,8 @@ export const baseStyle = 'flex items-center justify-center w-10 h-10 font-modal-
 export const dateNumVariants = {
   empty: 'text-gray-300 cursor-default',
   selected: 'bg-yellow-900 text-primary-black',
-  today: 'text-primary-black border border-gray-600 hover:border-none hover:bg-yellow-700',
+  today:
+    'text-primary-black border border-gray-600 [@media(hover:hover)]:hover:border-none [@media(hover:hover)]:hover:bg-yellow-700',
   past: 'text-gray-300 cursor-not-allowed',
-  available: 'text-primary-black hover:bg-yellow-700 cursor-pointer',
+  available: 'text-primary-black [@media(hover:hover)]:hover:bg-yellow-700 cursor-pointer',
 };


### PR DESCRIPTION
<!-- 이슈번호를 작성해주세요 -->
Closes #179 

## 특이사항
<!-- 구현 시 고려한 사항이나 주의점이 있다면 작성해주세요 -->
- 마우스/트랙패드에서만 hover 효과가 활성화. 터치와 S-Pen 모두 제외.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved date picker hover behavior to respect device capabilities: hover effects for "today" and "available" dates now only apply on devices that support hovering and fine pointers. This prevents unintended hover visuals on touch devices and improves clarity and touch usability in the calendar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->