### PR TITLE
[#196]; QA: 필터·재검색 결과 없을 때 ErrorNotice 미표시

### DIFF
--- a/pick-habju/src/components/ErrorNotice/ErrorNotice.tsx
+++ b/pick-habju/src/components/ErrorNotice/ErrorNotice.tsx
@@ -48,8 +48,8 @@ const ErrorNotice = ({ type, onClose, autoHideAfter, onAutoHide }: ErrorNoticePr
       case 'noResults':
         return (
           <>
-            <p className="w-full">조건에 맞는 합주실이 없어요.</p>
-            <p className="w-full">검색 조건을 다시 설정해주세요.</p>
+            <p className="w-full">예약 가능한 합주실을 찾지 못했어요.</p>
+            <p className="w-full">시간이나 지역을 변경하여 다시 검색해 볼까요?</p>
           </>
         );
       case 'loading':

--- a/pick-habju/src/pages/MapPage.tsx
+++ b/pick-habju/src/pages/MapPage.tsx
@@ -316,7 +316,6 @@ const MapPage = () => {
     <div className="relative h-full w-full">
       {isLoading && <MapLoadingSkeleton />}
       {hasNoResults && <ErrorNotice type="noResults" onClose={handleNoResultsClose} autoHideAfter={6000} />}
-
       <NaverMap
         ref={mapRef}
         initialCenter={lastQuery.center}

--- a/pick-habju/src/pages/MapPage.tsx
+++ b/pick-habju/src/pages/MapPage.tsx
@@ -314,7 +314,7 @@ const MapPage = () => {
 
   return (
     <div className="relative h-full w-full">
-      {isLoading && <MapLoadingSkeleton />}
+      {isLoading && !isReSearch && <MapLoadingSkeleton />}
       {hasNoResults && <ErrorNotice type="noResults" onClose={handleNoResultsClose} autoHideAfter={6000} />}
       <NaverMap
         ref={mapRef}

--- a/pick-habju/src/pages/MapPage.tsx
+++ b/pick-habju/src/pages/MapPage.tsx
@@ -52,9 +52,8 @@ const MapPage = () => {
   // ── 검색 텍스트 (브랜치명 필터) ──
   const [searchText, setSearchText] = useState('');
 
-  // ── noMatch 원인 추적 ──
-  /** 사용자가 마지막으로 변경한 필터·검색. noMatch 발생 시 원인 판별에 사용. */
-  const [lastChangedFilter, setLastChangedFilter] = useState<'partial' | 'favorite' | 'search' | null>(null);
+  // ── 재검색 추적 ("여기서 검색" 클릭 후 결과 없음 시 ErrorNotice 억제) ──
+  const [isReSearch, setIsReSearch] = useState(false);
 
   // ── 모달 상태 ──
   const [currentModal, setCurrentModal] = useState<{
@@ -90,46 +89,28 @@ const MapPage = () => {
     [branches, favoriteBizItemIds, isPartialFilterActive, isFavoriteFilterActive, searchText]
   );
 
-  /** API 결과가 없거나, 필터 없이도 표시할 방이 없음 (모든 방이 일부 시간만 가능인 경우 포함) */
+  /** API 결과가 없거나, 필터 없이도 표시할 방이 없음 (모든 방이 일부 시간만 가능인 경우 포함).
+   * 재검색("여기서 검색")으로 결과가 없는 경우는 ErrorNotice 없이 빈 지도만 표시. */
   const hasNoResults =
     !isLoading &&
+    !isReSearch &&
     (branches.length === 0 ||
       (!isPartialFilterActive && !isFavoriteFilterActive && !searchText && markerViewModels.length === 0));
-  /** 필터·검색이 활성화된 상태에서 표시할 마커가 없음.
-   * - partial 필터 / 검색텍스트 → markerViewModels 자체가 비어 있음
-   * - 즐겨찾기 필터 → markerViewModels는 있지만 favorite 'on'인 마커가 하나도 없음 */
-  const hasNoMatch =
-    !isLoading &&
-    branches.length > 0 &&
-    (isPartialFilterActive || isFavoriteFilterActive || !!searchText) &&
-    (markerViewModels.length === 0 || (isFavoriteFilterActive && markerViewModels.every((m) => m.favorite === 'off')));
-
-  /** noMatch 원인 필터. noMatch 중 다른 필터는 disabled되므로 lastChangedFilter가 항상 원인. */
-  const noMatchCause = hasNoMatch ? lastChangedFilter : null;
-
-  /** noMatch ErrorNotice 자동 숨김 시: 원인 필터 해제. 검색어는 자동 초기화 안 함(사용자가 직접 지워야 함). */
-  const handleNoMatchAutoHide = useCallback(() => {
-    if (noMatchCause === 'partial') setIsPartialFilterActive(false);
-    if (noMatchCause === 'favorite') setIsFavoriteFilterActive(false);
-  }, [noMatchCause]);
 
   /** noResults ErrorNotice 닫기(돌아가기·자동 숨김 공용). stable reference 유지를 위해 memoize. */
   const handleNoResultsClose = useCallback(() => {
     navigate(-1);
   }, [navigate]);
 
-  /** 필터·검색 변경 핸들러 — lastChangedFilter 갱신 포함 */
+  /** 필터·검색 변경 핸들러 */
   const handlePartialFilterToggle = useCallback((isActive: boolean) => {
     setIsPartialFilterActive(isActive);
-    setLastChangedFilter('partial');
   }, []);
   const handleFavoriteFilterToggle = useCallback((isActive: boolean) => {
     setIsFavoriteFilterActive(isActive);
-    setLastChangedFilter('favorite');
   }, []);
   const handleSearchChange = useCallback((text: string) => {
     setSearchText(text);
-    if (text) setLastChangedFilter('search');
   }, []);
 
   /**
@@ -281,12 +262,12 @@ const MapPage = () => {
 
   /** "여기서 검색" 클릭 시: 선택 UI·필터·검색어를 초기화한 뒤 재검색. */
   const handleSearchHereClick = useCallback(() => {
+    setIsReSearch(true);
     handleSearchHere(() => {
       resetSelectionUiState();
       setIsPartialFilterActive(false);
       setIsFavoriteFilterActive(false);
       setSearchText('');
-      setLastChangedFilter(null);
     });
   }, [handleSearchHere, resetSelectionUiState]);
 
@@ -335,13 +316,7 @@ const MapPage = () => {
     <div className="relative h-full w-full">
       {isLoading && <MapLoadingSkeleton />}
       {hasNoResults && <ErrorNotice type="noResults" onClose={handleNoResultsClose} autoHideAfter={6000} />}
-      {hasNoMatch && (
-        <ErrorNotice
-          type="noMatch"
-          autoHideAfter={noMatchCause !== 'search' ? 6000 : undefined}
-          onAutoHide={noMatchCause !== 'search' ? handleNoMatchAutoHide : undefined}
-        />
-      )}
+
       <NaverMap
         ref={mapRef}
         initialCenter={lastQuery.center}
@@ -370,15 +345,12 @@ const MapPage = () => {
             }
             navigate(RoutePaths.HOME);
           }}
-          disabled={hasNoMatch && noMatchCause !== 'search'}
         />
         <FilterSection
           isPartialFilterActive={isPartialFilterActive}
           onPartialFilterToggle={handlePartialFilterToggle}
           isFavoriteFilterActive={isFavoriteFilterActive}
           onFavoriteFilterToggle={handleFavoriteFilterToggle}
-          partialDisabled={hasNoMatch && noMatchCause !== 'partial'}
-          favoriteDisabled={hasNoMatch && noMatchCause !== 'favorite'}
         />
       </div>
 


### PR DESCRIPTION
<!-- 이슈번호를 작성해주세요 -->
Closes #196 

## 특이사항
<!-- 구현 시 고려한 사항이나 주의점이 있다면 작성해주세요 -->
- ErrorNotice 컴포넌트의 noMatch 타입 데드코드 일단 남겨뒀습니다.
- 찜한 합주실 필터링 문제는 추후 마커 새로운 방식으로 수정하면서 수정하겠습니다.

## 구현내용
- 필터(일부시간/찜) 적용 후 결과 없을 때 noMatch ErrorNotice 제거 → 빈 지도만 표시
- "여기서 검색" 후 결과 없을 때 noResults ErrorNotice 제거 → 빈 지도만 표시
- 메인화면 검색 후 결과 없는 경우(Case 1)는 기존 ErrorNotice + 6초 자동 뒤로가기 동작 유지
- lastChangedFilter, noMatchCause, handleNoMatchAutoHide, 필터·검색바 disabled 관련 로직 제거

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Re-search (via "Search Here") no longer shows a misleading no-results alert; the previous no-match error notice has been removed.

* **UI Changes**
  * Search and filter controls remain responsive after a prior no-match state; they are no longer temporarily disabled.
  * Loading indicator is suppressed during re-search.
  * No-results message text updated to: “예약 가능한 합주실을 찾지 못했어요.” / “시간이나 지역을 변경하여 다시 검색해 볼까요?”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->