### PR TITLE
[#205]; [FIX]: 마커 클러스터링 기준 마커 수 1로 수정

### DIFF
--- a/pick-habju/src/components/Map/NaverMap.tsx
+++ b/pick-habju/src/components/Map/NaverMap.tsx
@@ -445,7 +445,7 @@ const NaverMap = forwardRef<NaverMapHandle, NaverMapProps>(
         clusteringRef.current = new MarkerClustering({
           map,
           markers: markerArray,
-          minClusterSize: 2,
+          minClusterSize: 1,
           // 이 줌 레벨 이상에서는 클러스터를 해제하고 개별 마커를 표시
           maxZoom: 15,
           gridSize: 120,


### PR DESCRIPTION
<!-- 이슈번호를 작성해주세요 -->
Closes #205 

## 특이사항
<!-- 구현 시 고려한 사항이나 주의점이 있다면 작성해주세요 -->

## 구현내용
- `minClusterSize`를 2에서 1로 변경하여, 단독 마커(1개)도 클러스터 버블로 표시되도록 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved marker clustering behavior on maps for better visualization by adjusting the clustering threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->