### PR TITLE
[#213]; [FIX]: 지도 이동 후 마커 미세하게 이동하는 현상 해결 

### DIFF
--- a/pick-habju/public/lib/naver/MarkerClustering.js
+++ b/pick-habju/public/lib/naver/MarkerClustering.js
@@ -373,11 +373,31 @@ naver.maps.Util.ClassExtend(MarkerClustering, naver.maps.OverlayView, {
   },
 
   /**
+   * _redraw 전용: 개별 마커의 setMap 상태를 건드리지 않고 클러스터 데이터만 정리합니다.
+   * _softDestroy로 클러스터 마커(합산 아이콘)만 제거하고, 개별 마커 DOM은 유지합니다.
+   * @private
+   */
+  _softClearClusters: function () {
+    var clusters = this._clusters;
+
+    for (var i = 0, ii = clusters.length; i < ii; i++) {
+      clusters[i]._softDestroy();
+    }
+
+    naver.maps.Event.removeListener(this._markerRelations);
+
+    this._markerRelations = [];
+    this._clusters = [];
+  },
+
+  /**
    * 생성된 클러스터를 모두 제거하고, 다시 생성합니다.
+   * _softClearClusters를 사용해 개별 마커의 DOM 재삽입 없이 클러스터를 재구성합니다.
+   * 이후 _showMember/_hideMember가 실제 상태 변경이 필요한 마커만 setMap을 호출합니다.
    * @private
    */
   _redraw: function () {
-    this._clearClusters();
+    this._softClearClusters();
     this._createClusters();
     this._updateClusters();
   },
@@ -419,14 +439,7 @@ naver.maps.Util.ClassExtend(MarkerClustering, naver.maps.OverlayView, {
    * 지도의 Idle 상태 이벤트 핸들러입니다.
    */
   _onIdle: function () {
-    console.log('[MarkerClustering] _onIdle → _redraw 호출', {
-      clusterCount: this._clusters.length,
-      markerCount: this.getMarkers().length,
-      zoom: this.getMap().getZoom(),
-    });
-    console.time('[MarkerClustering] _redraw 소요시간');
     this._redraw();
-    console.timeEnd('[MarkerClustering] _redraw 소요시간');
   },
 
   /**
@@ -485,6 +498,26 @@ Cluster.prototype = {
     }
 
     this._clusterMarker.setMap(null);
+
+    this._clusterMarker = null;
+    this._clusterCenter = null;
+    this._clusterBounds = null;
+    this._relation = null;
+
+    this._clusterMember = [];
+  },
+
+  /**
+   * _redraw 전용: 멤버 마커의 setMap 상태를 건드리지 않고 데이터 구조만 정리합니다.
+   * 클러스터 마커(합산 아이콘)만 제거하고, 개별 마커의 DOM은 그대로 유지합니다.
+   * 이후 _showMember/_hideMember가 실제 필요한 변경만 수행합니다.
+   */
+  _softDestroy: function () {
+    naver.maps.Event.removeListener(this._relation);
+
+    if (this._clusterMarker) {
+      this._clusterMarker.setMap(null);
+    }
 
     this._clusterMarker = null;
     this._clusterCenter = null;
@@ -639,6 +672,7 @@ Cluster.prototype = {
 
   /**
    * 클러스터를 구성하는 마커를 노출합니다. 이때에는 클러스터 마커를 노출하지 않습니다.
+   * 이미 지도에 표시 중인 마커는 setMap을 건너뛰어 불필요한 DOM 재삽입을 방지합니다.
    * @private
    */
   _showMember: function () {
@@ -647,16 +681,19 @@ Cluster.prototype = {
       members = this._clusterMember;
 
     for (var i = 0, ii = members.length; i < ii; i++) {
-      members[i].setMap(map);
+      if (members[i].getMap() !== map) {
+        members[i].setMap(map);
+      }
     }
 
-    if (marker) {
+    if (marker && marker.getMap()) {
       marker.setMap(null);
     }
   },
 
   /**
    * 클러스터를 구성하는 마커를 노출하지 않습니다. 이때에는 클러스터 마커를 노출합니다.
+   * 이미 숨겨진 마커는 setMap을 건너뛰어 불필요한 DOM 조작을 방지합니다.
    * @private
    */
   _hideMember: function () {
@@ -665,7 +702,9 @@ Cluster.prototype = {
       members = this._clusterMember;
 
     for (var i = 0, ii = members.length; i < ii; i++) {
-      members[i].setMap(null);
+      if (members[i].getMap() !== null) {
+        members[i].setMap(null);
+      }
     }
 
     if (marker && !marker.getMap()) {

--- a/pick-habju/public/lib/naver/MarkerClustering.js
+++ b/pick-habju/public/lib/naver/MarkerClustering.js
@@ -392,11 +392,21 @@ naver.maps.Util.ClassExtend(MarkerClustering, naver.maps.OverlayView, {
 
   /**
    * 생성된 클러스터를 모두 제거하고, 다시 생성합니다.
-   * _softClearClusters를 사용해 개별 마커의 DOM 재삽입 없이 클러스터를 재구성합니다.
-   * 이후 _showMember/_hideMember가 실제 상태 변경이 필요한 마커만 setMap을 호출합니다.
+   * 마커 목록 변경 등 완전한 재구성이 필요한 경우 사용합니다.
    * @private
    */
   _redraw: function () {
+    this._clearClusters();
+    this._createClusters();
+    this._updateClusters();
+  },
+
+  /**
+   * idle/zoom 등 마커 목록은 동일한 상태에서의 재클러스터링 전용.
+   * 개별 마커의 DOM 재삽입 없이 클러스터를 재구성합니다.
+   * @private
+   */
+  _softRedraw: function () {
     this._softClearClusters();
     this._createClusters();
     this._updateClusters();
@@ -439,14 +449,14 @@ naver.maps.Util.ClassExtend(MarkerClustering, naver.maps.OverlayView, {
    * 지도의 Idle 상태 이벤트 핸들러입니다.
    */
   _onIdle: function () {
-    this._redraw();
+    this._softRedraw();
   },
 
   /**
    * 각 마커의 드래그 종료 이벤트 핸들러입니다.
    */
   _onDragEnd: function () {
-    this._redraw();
+    this._softRedraw();
   },
 });
 

--- a/pick-habju/public/lib/naver/MarkerClustering.js
+++ b/pick-habju/public/lib/naver/MarkerClustering.js
@@ -507,7 +507,9 @@ Cluster.prototype = {
       members[i].setMap(null);
     }
 
-    this._clusterMarker.setMap(null);
+    if (this._clusterMarker) {
+      this._clusterMarker.setMap(null);
+    }
 
     this._clusterMarker = null;
     this._clusterCenter = null;
@@ -612,10 +614,21 @@ Cluster.prototype = {
    * - 클러스터 마커 노출 여부
    */
   updateCluster: function () {
+    var clusterer = this._markerClusterer,
+      maxZoom = clusterer.getMaxZoom(),
+      currentZoom = clusterer.getMap().getZoom();
+
+    // maxZoom 이상에서는 개별 마커만 표시하므로 클러스터 마커 생성을 건너뛴다.
+    // 불필요한 DOM 삽입/제거(new Marker → 즉시 setMap(null))를 방지한다.
+    if (!this._clusterMarker && maxZoom <= currentZoom) {
+      this.checkByZoomAndMinClusterSize();
+      return;
+    }
+
     if (!this._clusterMarker) {
       var position;
 
-      if (this._markerClusterer.getAverageCenter()) {
+      if (clusterer.getAverageCenter()) {
         position = this._calcAverageCenter(this._clusterMember);
       } else {
         position = this._clusterCenter;
@@ -623,10 +636,10 @@ Cluster.prototype = {
 
       this._clusterMarker = new naver.maps.Marker({
         position: position,
-        map: this._markerClusterer.getMap(),
+        map: clusterer.getMap(),
       });
 
-      if (!this._markerClusterer.getDisableClickZoom()) {
+      if (!clusterer.getDisableClickZoom()) {
         this.enableClickZoom();
       }
     }

--- a/pick-habju/public/lib/naver/MarkerClustering.js
+++ b/pick-habju/public/lib/naver/MarkerClustering.js
@@ -523,6 +523,7 @@ Cluster.prototype = {
    * _redraw 전용: 멤버 마커의 setMap 상태를 건드리지 않고 데이터 구조만 정리합니다.
    * 클러스터 마커(합산 아이콘)만 제거하고, 개별 마커의 DOM은 그대로 유지합니다.
    * 이후 _showMember/_hideMember가 실제 필요한 변경만 수행합니다.
+   * @private
    */
   _softDestroy: function () {
     naver.maps.Event.removeListener(this._relation);

--- a/pick-habju/public/lib/naver/MarkerClustering.js
+++ b/pick-habju/public/lib/naver/MarkerClustering.js
@@ -419,7 +419,14 @@ naver.maps.Util.ClassExtend(MarkerClustering, naver.maps.OverlayView, {
    * 지도의 Idle 상태 이벤트 핸들러입니다.
    */
   _onIdle: function () {
+    console.log('[MarkerClustering] _onIdle → _redraw 호출', {
+      clusterCount: this._clusters.length,
+      markerCount: this.getMarkers().length,
+      zoom: this.getMap().getZoom(),
+    });
+    console.time('[MarkerClustering] _redraw 소요시간');
     this._redraw();
+    console.timeEnd('[MarkerClustering] _redraw 소요시간');
   },
 
   /**

--- a/pick-habju/public/lib/naver/MarkerClustering.js
+++ b/pick-habju/public/lib/naver/MarkerClustering.js
@@ -439,7 +439,9 @@ naver.maps.Util.ClassExtend(MarkerClustering, naver.maps.OverlayView, {
    * 지도의 Idle 상태 이벤트 핸들러입니다.
    */
   _onIdle: function () {
+    console.log('[MC] _onIdle start');
     this._redraw();
+    console.log('[MC] _onIdle end');
   },
 
   /**
@@ -636,14 +638,10 @@ Cluster.prototype = {
       maxZoom = clusterer.getMaxZoom(),
       currentZoom = clusterer.getMap().getZoom();
 
-    if (this.getCount() < minClusterSize) {
+    if (this.getCount() < minClusterSize || maxZoom <= currentZoom) {
       this._showMember();
     } else {
       this._hideMember();
-
-      if (maxZoom <= currentZoom) {
-        this._showMember();
-      }
     }
   },
 
@@ -680,11 +678,14 @@ Cluster.prototype = {
       marker = this._clusterMarker,
       members = this._clusterMember;
 
+    var setMapCount = 0;
     for (var i = 0, ii = members.length; i < ii; i++) {
       if (members[i].getMap() !== map) {
         members[i].setMap(map);
+        setMapCount++;
       }
     }
+    if (setMapCount > 0) console.log('[MC] _showMember: setMap(map) called on', setMapCount, 'markers');
 
     if (marker && marker.getMap()) {
       marker.setMap(null);

--- a/pick-habju/public/lib/naver/MarkerClustering.js
+++ b/pick-habju/public/lib/naver/MarkerClustering.js
@@ -439,8 +439,6 @@ naver.maps.Util.ClassExtend(MarkerClustering, naver.maps.OverlayView, {
    * 지도의 Idle 상태 이벤트 핸들러입니다.
    */
   _onIdle: function () {
-    console.log('[MC] _onIdle — DISABLED FOR TEST');
-    return; // ★ 테스트: MarkerClustering idle도 비활성화
     this._redraw();
   },
 
@@ -678,14 +676,11 @@ Cluster.prototype = {
       marker = this._clusterMarker,
       members = this._clusterMember;
 
-    var setMapCount = 0;
     for (var i = 0, ii = members.length; i < ii; i++) {
       if (members[i].getMap() !== map) {
         members[i].setMap(map);
-        setMapCount++;
       }
     }
-    if (setMapCount > 0) console.log('[MC] _showMember: setMap(map) called on', setMapCount, 'markers');
 
     if (marker && marker.getMap()) {
       marker.setMap(null);

--- a/pick-habju/public/lib/naver/MarkerClustering.js
+++ b/pick-habju/public/lib/naver/MarkerClustering.js
@@ -439,9 +439,9 @@ naver.maps.Util.ClassExtend(MarkerClustering, naver.maps.OverlayView, {
    * 지도의 Idle 상태 이벤트 핸들러입니다.
    */
   _onIdle: function () {
-    console.log('[MC] _onIdle start');
+    console.log('[MC] _onIdle — DISABLED FOR TEST');
+    return; // ★ 테스트: MarkerClustering idle도 비활성화
     this._redraw();
-    console.log('[MC] _onIdle end');
   },
 
   /**

--- a/pick-habju/public/lib/naver/MarkerClustering.js
+++ b/pick-habju/public/lib/naver/MarkerClustering.js
@@ -620,7 +620,9 @@ Cluster.prototype = {
 
     // maxZoom 이상에서는 개별 마커만 표시하므로 클러스터 마커 생성을 건너뛴다.
     // 불필요한 DOM 삽입/제거(new Marker → 즉시 setMap(null))를 방지한다.
-    if (!this._clusterMarker && maxZoom <= currentZoom) {
+    // updateCluster() 진입 시점에 _clusterMarker는 항상 null(_createClusters에서 새로 생성)이므로
+    // !this._clusterMarker 조건은 불필요하다.
+    if (maxZoom <= currentZoom) {
       this.checkByZoomAndMinClusterSize();
       return;
     }

--- a/pick-habju/public/lib/naver/MarkerClustering.js
+++ b/pick-habju/public/lib/naver/MarkerClustering.js
@@ -619,15 +619,6 @@ Cluster.prototype = {
       maxZoom = clusterer.getMaxZoom(),
       currentZoom = clusterer.getMap().getZoom();
 
-    // maxZoom 이상에서는 개별 마커만 표시하므로 클러스터 마커 생성을 건너뛴다.
-    // 불필요한 DOM 삽입/제거(new Marker → 즉시 setMap(null))를 방지한다.
-    // updateCluster() 진입 시점에 _clusterMarker는 항상 null(_createClusters에서 새로 생성)이므로
-    // !this._clusterMarker 조건은 불필요하다.
-    if (maxZoom <= currentZoom) {
-      this.checkByZoomAndMinClusterSize();
-      return;
-    }
-
     if (!this._clusterMarker) {
       var position;
 
@@ -637,9 +628,12 @@ Cluster.prototype = {
         position = this._clusterCenter;
       }
 
+      // maxZoom 이상에서는 개별 마커만 표시하므로 map 없이 생성한다.
+      // DOM에 삽입되지 않아 불필요한 DOM 조작을 방지하면서,
+      // _clusterMarker가 항상 존재하므로 다른 메서드에서 null 참조가 발생하지 않는다.
       this._clusterMarker = new naver.maps.Marker({
         position: position,
-        map: clusterer.getMap(),
+        map: maxZoom <= currentZoom ? null : clusterer.getMap(),
       });
 
       if (!clusterer.getDisableClickZoom()) {

--- a/pick-habju/src/components/Map/NaverMap.tsx
+++ b/pick-habju/src/components/Map/NaverMap.tsx
@@ -280,7 +280,6 @@ const NaverMap = forwardRef<NaverMapHandle, NaverMapProps>(
               markerLevelsRef.current.set(m.id, newLevel);
 
               if (prevLevel !== newLevel) {
-                console.log(`[Collision] setIcon: ${m.id} level ${prevLevel}→${newLevel}`);
                 const marker = markerInstancesRef.current.get(m.id);
                 if (marker) {
                   marker.setZIndex(m.favorite === 'on' ? 1 : 0);
@@ -305,9 +304,32 @@ const NaverMap = forwardRef<NaverMapHandle, NaverMapProps>(
 
           runCollisionDetectionRef.current = runCollisionDetection;
 
+          /**
+           * 마커 DOM 위치를 정수 픽셀로 스냅한다.
+           * 네이버 지도 GL SDK는 idle 시점에 마커 DOM 요소의 좌표를 부동소수점으로
+           * 재계산하는데, 이때 서브픽셀 차이로 마커가 미세하게 이동하는 현상이 발생한다.
+           * left/top 또는 translate 값을 반올림해 서브픽셀 이동을 제거한다.
+           */
+          const snapMarkerPositions = () => {
+            for (const marker of markerInstancesRef.current.values()) {
+              if (marker.getMap() === null) continue;
+              const el = marker.getElement() as HTMLElement | null;
+              if (!el) continue;
+
+              const { left, top, transform } = el.style;
+
+              if (transform && transform.includes('translate')) {
+                el.style.transform = transform.replace(
+                  /translate\(([^,]+),\s*([^)]+)\)/,
+                  (_, x, y) => `translate(${Math.round(parseFloat(x))}px, ${Math.round(parseFloat(y))}px)`
+                );
+              }
+              if (left) el.style.left = Math.round(parseFloat(left)) + 'px';
+              if (top) el.style.top = Math.round(parseFloat(top)) + 'px';
+            }
+          };
+
           idleListenerRef.current = naver.maps.Event.addListener(map, 'idle', () => {
-            console.log('[NaverMap] idle fired — ALL PROCESSING DISABLED FOR TEST');
-            return; // ★ 테스트: idle 시 아무것도 하지 않음
             // 뷰포트 변경 알림
             const viewportCb = onViewportChangeRef.current;
             if (viewportCb) viewportCb(getViewportFromMap(map));
@@ -317,7 +339,8 @@ const NaverMap = forwardRef<NaverMapHandle, NaverMapProps>(
             // 결과가 동일하다. 플래그를 소비한 뒤 즉시 리셋.
             if (suppressCollisionRef.current) {
               suppressCollisionRef.current = false;
-              console.log('[NaverMap] collision suppressed (panTo)');
+              // 충돌 감지는 건너뛰되, 마커 위치 스냅은 항상 수행
+              idleCollisionRafRef.current = requestAnimationFrame(snapMarkerPositions);
               return;
             }
 
@@ -328,8 +351,10 @@ const NaverMap = forwardRef<NaverMapHandle, NaverMapProps>(
             // 복원하기 전에 우리 코드가 실행되면 visibleModels가 비어 충돌 감지가 무시된다.
             // requestAnimationFrame으로 한 프레임 뒤에 실행하면 MarkerClustering 처리가
             // 완료된 이후에 충돌 감지가 실행된다.
-            console.log('[NaverMap] scheduling collision detection');
-            idleCollisionRafRef.current = requestAnimationFrame(runCollisionDetection);
+            idleCollisionRafRef.current = requestAnimationFrame(() => {
+              runCollisionDetection();
+              snapMarkerPositions();
+            });
           });
 
           mapClickListenerRef.current = naver.maps.Event.addListener(map, 'click', () => {

--- a/pick-habju/src/components/Map/NaverMap.tsx
+++ b/pick-habju/src/components/Map/NaverMap.tsx
@@ -306,7 +306,8 @@ const NaverMap = forwardRef<NaverMapHandle, NaverMapProps>(
           runCollisionDetectionRef.current = runCollisionDetection;
 
           idleListenerRef.current = naver.maps.Event.addListener(map, 'idle', () => {
-            console.log('[NaverMap] idle fired');
+            console.log('[NaverMap] idle fired — ALL PROCESSING DISABLED FOR TEST');
+            return; // ★ 테스트: idle 시 아무것도 하지 않음
             // 뷰포트 변경 알림
             const viewportCb = onViewportChangeRef.current;
             if (viewportCb) viewportCb(getViewportFromMap(map));

--- a/pick-habju/src/components/Map/NaverMap.tsx
+++ b/pick-habju/src/components/Map/NaverMap.tsx
@@ -280,6 +280,7 @@ const NaverMap = forwardRef<NaverMapHandle, NaverMapProps>(
               markerLevelsRef.current.set(m.id, newLevel);
 
               if (prevLevel !== newLevel) {
+                console.log(`[Collision] setIcon: ${m.id} level ${prevLevel}→${newLevel}`);
                 const marker = markerInstancesRef.current.get(m.id);
                 if (marker) {
                   marker.setZIndex(m.favorite === 'on' ? 1 : 0);
@@ -305,6 +306,7 @@ const NaverMap = forwardRef<NaverMapHandle, NaverMapProps>(
           runCollisionDetectionRef.current = runCollisionDetection;
 
           idleListenerRef.current = naver.maps.Event.addListener(map, 'idle', () => {
+            console.log('[NaverMap] idle fired');
             // 뷰포트 변경 알림
             const viewportCb = onViewportChangeRef.current;
             if (viewportCb) viewportCb(getViewportFromMap(map));
@@ -314,6 +316,7 @@ const NaverMap = forwardRef<NaverMapHandle, NaverMapProps>(
             // 결과가 동일하다. 플래그를 소비한 뒤 즉시 리셋.
             if (suppressCollisionRef.current) {
               suppressCollisionRef.current = false;
+              console.log('[NaverMap] collision suppressed (panTo)');
               return;
             }
 
@@ -324,6 +327,7 @@ const NaverMap = forwardRef<NaverMapHandle, NaverMapProps>(
             // 복원하기 전에 우리 코드가 실행되면 visibleModels가 비어 충돌 감지가 무시된다.
             // requestAnimationFrame으로 한 프레임 뒤에 실행하면 MarkerClustering 처리가
             // 완료된 이후에 충돌 감지가 실행된다.
+            console.log('[NaverMap] scheduling collision detection');
             idleCollisionRafRef.current = requestAnimationFrame(runCollisionDetection);
           });
 

--- a/pick-habju/src/components/Map/NaverMap.tsx
+++ b/pick-habju/src/components/Map/NaverMap.tsx
@@ -304,31 +304,6 @@ const NaverMap = forwardRef<NaverMapHandle, NaverMapProps>(
 
           runCollisionDetectionRef.current = runCollisionDetection;
 
-          /**
-           * 마커 DOM 위치를 정수 픽셀로 스냅한다.
-           * 네이버 지도 GL SDK는 idle 시점에 마커 DOM 요소의 좌표를 부동소수점으로
-           * 재계산하는데, 이때 서브픽셀 차이로 마커가 미세하게 이동하는 현상이 발생한다.
-           * left/top 또는 translate 값을 반올림해 서브픽셀 이동을 제거한다.
-           */
-          const snapMarkerPositions = () => {
-            for (const marker of markerInstancesRef.current.values()) {
-              if (marker.getMap() === null) continue;
-              const el = marker.getElement() as HTMLElement | null;
-              if (!el) continue;
-
-              const { left, top, transform } = el.style;
-
-              if (transform && transform.includes('translate')) {
-                el.style.transform = transform.replace(
-                  /translate\(([^,]+),\s*([^)]+)\)/,
-                  (_, x, y) => `translate(${Math.round(parseFloat(x))}px, ${Math.round(parseFloat(y))}px)`
-                );
-              }
-              if (left) el.style.left = Math.round(parseFloat(left)) + 'px';
-              if (top) el.style.top = Math.round(parseFloat(top)) + 'px';
-            }
-          };
-
           idleListenerRef.current = naver.maps.Event.addListener(map, 'idle', () => {
             // 뷰포트 변경 알림
             const viewportCb = onViewportChangeRef.current;
@@ -339,8 +314,6 @@ const NaverMap = forwardRef<NaverMapHandle, NaverMapProps>(
             // 결과가 동일하다. 플래그를 소비한 뒤 즉시 리셋.
             if (suppressCollisionRef.current) {
               suppressCollisionRef.current = false;
-              // 충돌 감지는 건너뛰되, 마커 위치 스냅은 항상 수행
-              idleCollisionRafRef.current = requestAnimationFrame(snapMarkerPositions);
               return;
             }
 
@@ -351,10 +324,7 @@ const NaverMap = forwardRef<NaverMapHandle, NaverMapProps>(
             // 복원하기 전에 우리 코드가 실행되면 visibleModels가 비어 충돌 감지가 무시된다.
             // requestAnimationFrame으로 한 프레임 뒤에 실행하면 MarkerClustering 처리가
             // 완료된 이후에 충돌 감지가 실행된다.
-            idleCollisionRafRef.current = requestAnimationFrame(() => {
-              runCollisionDetection();
-              snapMarkerPositions();
-            });
+            idleCollisionRafRef.current = requestAnimationFrame(runCollisionDetection);
           });
 
           mapClickListenerRef.current = naver.maps.Event.addListener(map, 'click', () => {


### PR DESCRIPTION
<!-- 이슈번호를 작성해주세요 -->
Closes #213 

## 특이사항
<!-- 구현 시 고려한 사항이나 주의점이 있다면 작성해주세요 -->

## 구현내용
1. MarkerClustering idle 시 불필요한 마커 DOM 제거/재삽입 방지
- 기존: 매 idle마다 _clearClusters() → destroy() → 모든 마커 setMap(null) 후 setMap(map)으로 재삽입하는 사이클이 발생
- _softRedraw 추가: idle/드래그 시에는 클러스터 데이터만 정리하고 개별 마커의 DOM은 유지. 마커 목록 자체가 변경될 때는 기존 _redraw로 완전 정리
- updateCluster에서 zoom > maxZoom일 때 클러스터 마커 생성을 건너뛰어 불필요한 DOM 삽입/제거 방지



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved map responsiveness by avoiding unnecessary marker recreations and redundant visibility updates, speeding panning/zooming and drag operations.
  * Reduced work during redraws so cluster updates are lighter and faster.

* **Bug Fixes**
  * More consistent cluster behavior across zoom changes and marker interactions, preventing flicker or incorrect visibility during transitions.
  * Fixed cases where stale cluster markers could remain visible after updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->