### PR TITLE
[#160]; [FIX]: 소수 슬라이드에서 Swiper loop 경고·오작동 버그 수정

### DIFF
--- a/pick-habju/src/components/CardCarousel/CardCarousel.tsx
+++ b/pick-habju/src/components/CardCarousel/CardCarousel.tsx
@@ -118,7 +118,7 @@ const CardCarousel = ({
    *  rooms 참조가 바뀌지 않는 한 동일 배열을 반환하여 불필요한 재생성을 방지한다. */
   const loopSlides = useMemo(
     () =>
-      rooms.length === 0 || rooms.length >= MIN_LOOP_SLIDES
+      rooms.length <= 1 || rooms.length >= MIN_LOOP_SLIDES
         ? rooms
         : Array.from({ length: Math.ceil(MIN_LOOP_SLIDES / rooms.length) }, () => rooms).flat(),
     [rooms]

--- a/pick-habju/src/components/CardCarousel/CardCarousel.tsx
+++ b/pick-habju/src/components/CardCarousel/CardCarousel.tsx
@@ -13,6 +13,14 @@ import { ChevronVariant } from '../Chevron/ChevronEnums';
 
 import 'swiper/css';
 
+/**
+ * Swiper loop가 안정적으로 작동하기 위한 최소 슬라이드 수.
+ * 모바일(slidesPerView:'auto' + centeredSlides + loopAdditionalSlides:2) 기준
+ * 4개 이하에서 loop 경고·오작동이 확인되어 5로 설정.
+ * 원본이 이보다 적으면 배열을 반복하여 패딩한다.
+ */
+const MIN_LOOP_SLIDES = 5;
+
 /** Chevron 컨테이너 스타일: nested 선택자 분리로 가독성 향상 */
 const CHEVRON_CONTAINER_STYLES = `
   w-full justify-between pointer-events-none
@@ -90,14 +98,6 @@ const CarouselSlideContent = memo(function CarouselSlideContent({
  * - 사용자 스와이프 시 onCardChange로 선택 룸 ID를 상위에 전달.
  * - isOpen / rooms.length에 따라 AnimatePresence로 슬라이드 인·아웃 처리.
  */
-/**
- * Swiper loop가 안정적으로 작동하기 위한 최소 슬라이드 수.
- * 모바일(slidesPerView:'auto' + centeredSlides + loopAdditionalSlides:2) 기준
- * 4개 이하에서 loop 경고·오작동이 확인되어 5로 설정.
- * 원본이 이보다 적으면 배열을 반복하여 패딩한다.
- */
-const MIN_LOOP_SLIDES = 5;
-
 const CardCarousel = ({
   rooms,
   selectedRoomId,

--- a/pick-habju/src/components/CardCarousel/CardCarousel.tsx
+++ b/pick-habju/src/components/CardCarousel/CardCarousel.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useRef, useState } from 'react';
+import { memo, useEffect, useMemo, useRef, useState } from 'react';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { Navigation } from 'swiper/modules';
 import type { Swiper as SwiperType } from 'swiper';
@@ -90,6 +90,14 @@ const CarouselSlideContent = memo(function CarouselSlideContent({
  * - 사용자 스와이프 시 onCardChange로 선택 룸 ID를 상위에 전달.
  * - isOpen / rooms.length에 따라 AnimatePresence로 슬라이드 인·아웃 처리.
  */
+/**
+ * Swiper loop가 안정적으로 작동하기 위한 최소 슬라이드 수.
+ * 모바일(slidesPerView:'auto' + centeredSlides + loopAdditionalSlides:2) 기준
+ * 4개 이하에서 loop 경고·오작동이 확인되어 5로 설정.
+ * 원본이 이보다 적으면 배열을 반복하여 패딩한다.
+ */
+const MIN_LOOP_SLIDES = 5;
+
 const CardCarousel = ({
   rooms,
   selectedRoomId,
@@ -104,6 +112,18 @@ const CardCarousel = ({
   const isDesktop = !isMobile;
   const [swiperInstance, setSwiperInstance] = useState<SwiperType | null>(null);
 
+  const loopActive = rooms.length > 1;
+
+  /** 슬라이드가 부족하면 원본을 반복하여 Swiper loop 최소 요구치를 충족.
+   *  rooms 참조가 바뀌지 않는 한 동일 배열을 반환하여 불필요한 재생성을 방지한다. */
+  const loopSlides = useMemo(
+    () =>
+      rooms.length === 0 || rooms.length >= MIN_LOOP_SLIDES
+        ? rooms
+        : Array.from({ length: Math.ceil(MIN_LOOP_SLIDES / rooms.length) }, () => rooms).flat(),
+    [rooms]
+  );
+
   /** Swiper loop 초기화 중 발생하는 spurious onSlideChange를 무시하기 위한 flag.
    *  onSwiper(마운트)에서 false로 리셋, 첫 슬라이드 동기화 완료 후 true로 전환한다. */
   const isSwipeReadyRef = useRef(false);
@@ -114,7 +134,7 @@ const CardCarousel = ({
     setSwiperInstance(swiper);
   };
 
-  /** 지도 핀 클릭(selectedRoomId 변경) 시 해당 슬라이드로 동기화. Loop 모드이므로 slideToLoop 사용 */
+  /** 지도 핀 클릭(selectedRoomId 변경) 시 해당 슬라이드로 동기화 */
   useEffect(() => {
     if (!isOpen) {
       isSwipeReadyRef.current = false;
@@ -130,14 +150,25 @@ const CardCarousel = ({
       return;
     }
 
-    const index = rooms.findIndex((room) => room.bizItemId === selectedRoomId);
-    if (index !== -1) {
-      if (swiperInstance.realIndex !== index) {
-        swiperInstance.slideToLoop(index);
+    const currentBizItemId = loopSlides[swiperInstance.realIndex]?.bizItemId;
+    if (currentBizItemId !== selectedRoomId) {
+      const current = swiperInstance.realIndex;
+      const total = loopSlides.length;
+      let nearest = -1;
+      let minDist = Infinity;
+      for (let i = 0; i < total; i++) {
+        if (loopSlides[i].bizItemId !== selectedRoomId) continue;
+        const forward = (i - current + total) % total;
+        const dist = Math.min(forward, total - forward);
+        if (dist < minDist) {
+          minDist = dist;
+          nearest = i;
+        }
       }
+      if (nearest !== -1) swiperInstance.slideToLoop(nearest);
     }
     isSwipeReadyRef.current = true;
-  }, [selectedRoomId, isOpen, swiperInstance, rooms]);
+  }, [selectedRoomId, isOpen, swiperInstance, rooms, loopSlides]);
 
   /** Swiper 마운트 시점의 selectedRoomId 기반 초기 슬라이드 인덱스.
    *  Swiper는 initialSlide를 마운트 시에만 사용하므로 매 render마다 계산해도 안전하다. */
@@ -191,7 +222,7 @@ const CardCarousel = ({
                 role="region"
                 aria-label="룸 카드 캐러셀"
                 modules={[Navigation]}
-                loop={true}
+                loop={loopActive}
                 loopAdditionalSlides={2}
                 navigation={false}
                 initialSlide={initialSlide}
@@ -199,7 +230,7 @@ const CardCarousel = ({
                 {...getSwiperProps(isDesktop)}
                 onSlideChangeTransitionEnd={(swiper) => {
                   if (!isSwipeReadyRef.current) return;
-                  const currentRoom = rooms[swiper.realIndex];
+                  const currentRoom = loopSlides[swiper.realIndex];
                   if (currentRoom) {
                     if (currentRoom.bizItemId !== selectedRoomId) {
                       onCardChange(currentRoom.bizItemId);
@@ -209,9 +240,8 @@ const CardCarousel = ({
                 }}
                 className="w-full h-full !py-8"
               >
-                {rooms.map((room) => (
-                  // [L6] 슬라이드 래퍼: 데스크탑 !w-full(1장 꽉 참), 모바일 !w-auto
-                  <SwiperSlide key={room.bizItemId} className={isDesktop ? '!w-full' : '!w-auto'}>
+                {loopSlides.map((room, index) => (
+                  <SwiperSlide key={`${room.bizItemId}-${index}`} className={isDesktop ? '!w-full' : '!w-auto'}>
                     <CarouselSlideContent room={room} isMobile={isMobile} onBookClick={onBookClick} />
                   </SwiperSlide>
                 ))}

--- a/pick-habju/src/components/CardCarousel/CardCarousel.tsx
+++ b/pick-habju/src/components/CardCarousel/CardCarousel.tsx
@@ -142,10 +142,12 @@ const CardCarousel = ({
     }
     if (!swiperInstance || rooms.length === 0) return;
 
+    const slideTo = loopActive
+      ? (i: number) => swiperInstance.slideToLoop(i)
+      : (i: number) => swiperInstance.slideTo(i);
+
     if (selectedRoomId === null) {
-      if (swiperInstance.realIndex !== 0) {
-        swiperInstance.slideToLoop(0);
-      }
+      if (swiperInstance.realIndex !== 0) slideTo(0);
       isSwipeReadyRef.current = true;
       return;
     }
@@ -165,10 +167,10 @@ const CardCarousel = ({
           nearest = i;
         }
       }
-      if (nearest !== -1) swiperInstance.slideToLoop(nearest);
+      if (nearest !== -1) slideTo(nearest);
     }
     isSwipeReadyRef.current = true;
-  }, [selectedRoomId, isOpen, swiperInstance, rooms, loopSlides]);
+  }, [selectedRoomId, isOpen, swiperInstance, rooms, loopSlides, loopActive]);
 
   /** Swiper 마운트 시점의 selectedRoomId 기반 초기 슬라이드 인덱스.
    *  Swiper는 initialSlide를 마운트 시에만 사용하므로 매 render마다 계산해도 안전하다. */

--- a/pick-habju/src/components/CardCarousel/CardCarousel.tsx
+++ b/pick-habju/src/components/CardCarousel/CardCarousel.tsx
@@ -170,7 +170,9 @@ const CardCarousel = ({
       if (nearest !== -1) slideTo(nearest);
     }
     isSwipeReadyRef.current = true;
-  }, [selectedRoomId, isOpen, swiperInstance, rooms, loopSlides, loopActive]);
+    // loopSlides·loopActive는 rooms에서 파생되므로 rooms 변경 시 항상 최신 값 참조
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedRoomId, isOpen, swiperInstance, rooms]);
 
   /** Swiper 마운트 시점의 selectedRoomId 기반 초기 슬라이드 인덱스.
    *  Swiper는 initialSlide를 마운트 시에만 사용하므로 매 render마다 계산해도 안전하다. */


### PR DESCRIPTION
<!-- 이슈번호를 작성해주세요 -->
Closes #160 

## 특이사항
<!-- 구현 시 고려한 사항이나 주의점이 있다면 작성해주세요 -->
- Swiper 에서 loop 모드 사용할 때 슬라이드가 4개 이하이면 최소 슬라이드 수를 충족하지 못해 무한 루프 작동 안 하고 같은 카드 반복됨.

## 구현내용
- 원본 슬라이드가 5개 미만이면 배열을 반복 패딩하여 loop 최소 요구치 충족
- 마커 클릭 시 복사본 중 현재 위치에서 가장 가까운 슬라이드로 이동
- 같은 룸의 다른 복사본에 있을 때 불필요한 slideToLoop 호출 방지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed carousel looping and padding so short lists no longer cause unstable or repeating slides.
  * Resolved mismatches between carousel position and selected item so selection and view stay synchronized.
  * Made slide-change handling more reliable so the displayed item consistently reflects navigation and selection.

* **Improvements**
  * Stabilized slide counts for smoother looping and transitions.
  * Map clustering: cluster markers no longer appear at or above max zoom, reducing clutter and improving zoom behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->